### PR TITLE
Kernel versioning fixes

### DIFF
--- a/eclass/cros-kernel2.eclass
+++ b/eclass/cros-kernel2.eclass
@@ -408,7 +408,6 @@ cros-kernel2_src_install() {
 	if cros_chkconfig_present MODULES; then
 		kmake INSTALL_MOD_PATH="${D}" modules_install
 	fi
-	kmake INSTALL_MOD_PATH="${D}" firmware_install
 
 	local version=$(kernelversion)
 	if use arm; then

--- a/sys-kernel/coreos-kernel/coreos-kernel-3.9.5-r2.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-3.9.5-r2.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2013 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: /var/cvsroot/gentoo-x86/sys-kernel/vanilla-sources/vanilla-sources-3.7.5.ebuild,v 1.1 2013/01/28 13:18:54 ago Exp $
+
+EAPI=4
+CROS_WORKON_COMMIT="da3093ad9f44ba53c3f254b4392f3c742dee41d3"
+CROS_WORKON_TREE="0ff44b050e7f57e7d3743a44af2c9211da30bdb4"
+CROS_WORKON_REPO="git://github.com"
+CROS_WORKON_PROJECT="coreos/linux"
+inherit cros-workon cros-kernel2
+
+DEPEND="
+	sys-devel/bc
+"
+
+DESCRIPTION="CoreOS kernel"
+HOMEPAGE="http://www.kernel.org"
+SRC_URI="${KERNEL_URI}"
+
+KEYWORDS="amd64 arm x86"
+IUSE="deblob"
+
+src_prepare() {
+	epatch "${FILESDIR}"/no_firmware.patch
+}

--- a/sys-kernel/coreos-kernel/files/no_firmware.patch
+++ b/sys-kernel/coreos-kernel/files/no_firmware.patch
@@ -1,0 +1,37 @@
+From: Greg Kroah-Hartman <greg@kroah.com>
+Subject: [PATCH] firmware: disable the firmware path entirely
+
+We really don't want to build firmware images into the kernel package at
+all, so rip out all references to the firmware directory that we can
+fine.
+
+
+diff --git a/Makefile b/Makefile
+index 8818c95..0beba841 100644
+--- a/Makefile
++++ b/Makefile
+@@ -519,7 +519,7 @@ scripts: scripts_basic include/config/auto.conf include/config/tristate.conf \
+ 
+ # Objects we will link into vmlinux / subdirs we need to visit
+ init-y		:= init/
+-drivers-y	:= drivers/ sound/ firmware/
++drivers-y	:= drivers/ sound/
+ net-y		:= net/
+ libs-y		:= lib/
+ core-y		:= usr/
+@@ -944,7 +944,6 @@ modules: $(vmlinux-dirs) $(if $(KBUILD_BUILTIN),vmlinux) modules.builtin
+ 	$(Q)$(AWK) '!x[$$0]++' $(vmlinux-dirs:%=$(objtree)/%/modules.order) > $(objtree)/modules.order
+ 	@$(kecho) '  Building modules, stage 2.';
+ 	$(Q)$(MAKE) -f $(srctree)/scripts/Makefile.modpost
+-	$(Q)$(MAKE) -f $(srctree)/scripts/Makefile.fwinst obj=firmware __fw_modbuild
+ 
+ modules.builtin: $(vmlinux-dirs:%=%/modules.builtin)
+ 	$(Q)$(AWK) '!x[$$0]++' $^ > $(objtree)/modules.builtin
+@@ -980,7 +979,6 @@ _modinst_:
+ # boot script depmod is the master version.
+ PHONY += _modinst_post
+ _modinst_post: _modinst_
+-	$(Q)$(MAKE) -f $(srctree)/scripts/Makefile.fwinst obj=firmware __fw_modinst
+ 	$(call cmd,depmod)
+ 
+ ifeq ($(CONFIG_MODULE_SIG), y)


### PR DESCRIPTION
The fixes here allow multiple kernel packages to be installed / built at the same time.

Two things are done:
- place the debug kernel image into a versioned directory
- do not build the firmware files, or install them, as the kernel does not want to version those directories.
