### PR TITLE
fix(make.conf): Disable force-mirror

### DIFF
--- a/coreos/config/make.conf.common-target
+++ b/coreos/config/make.conf.common-target
@@ -22,7 +22,7 @@ PORTAGE_TMPDIR=${ROOT}tmp/
 PORT_LOGDIR=${ROOT}tmp/portage/logs/
 
 FEATURES="allow-missing-manifests buildpkg clean-logs -collision-protect
-          -ebuild-locks force-mirror nodoc noinfo noman parallel-install
+          -ebuild-locks -force-mirror nodoc noinfo noman parallel-install
           sandbox splitdebug -strict userfetch userpriv usersandbox
           -unknown-features-warn"
 


### PR DESCRIPTION
This feature forces emerge to only fetch sources from mirrors, never the
SRC_URI provided in actual ebuilds. Disabling this should fix our issues
with portage tarballs vanishing. :-D
