### PR TITLE
Fix docker container networking

### DIFF
--- a/app-emulation/docker/files/docker.service
+++ b/app-emulation/docker/files/docker.service
@@ -1,6 +1,9 @@
 [Service]
 Type=forking
 ExecStartPre=/bin/mount --make-rprivate /
+# Enable forwarding to allow NAT to work
+# TODO: Move this to sysctl.conf
+ExecStartPre=/sbin/sysctl -w net.ipv4.ip_forward=1
 
 # HACK: for some reason docker is crashing when exiting a container when being
 # supervised by systemd. Fork out for now. Real solution should be:


### PR DESCRIPTION
This PR fixes the network and allows the container to access the Internet.

The following changes are made by this PR:
1. docker is allowed to set up its own bridge, docker0.
This means it'll take care of setting up NAT via iptables MASQUERADE.
2. enable IPv4 forwarding so packets are actually forwarded
This will have to be moved to sysctl.conf when it'll be used.
