### PR TITLE
fix(sys-apps/efunctions): Fix INSTALL_MASK to remove init.d

### DIFF
--- a/coreos/config/env/sys-apps/efunctions
+++ b/coreos/config/env/sys-apps/efunctions
@@ -1,0 +1,3 @@
+# Don't filter out /etc/init.d/functions.sh
+PKG_INSTALL_MASK="${PKG_INSTALL_MASK/\/etc\/init.d}"
+INSTALL_MASK="${INSTALL_MASK/\/etc\/init.d}"


### PR DESCRIPTION
When installing with the default make.conf in full effect
/etc/init.d/functions.sh will be excluded which is the whole point of
the efunctions package in the first place. This should fix that.
