### PR TITLE
fix(config): Switch distfiles mirror list to our own

### DIFF
--- a/coreos/config/make.conf.amd64-host
+++ b/coreos/config/make.conf.amd64-host
@@ -47,10 +47,10 @@ PORTAGE_BINHOST="
     http://storage.core-os.net/coreos/sdk/experimental/20130621235834/pkgs/
 "
 
-	#http://gentoo.osuosl.org/
 GENTOO_MIRRORS="
-	https://commondatastorage.googleapis.com/chromeos-mirror/gentoo
-    http://gsdview.appspot.com/chromeos-localmirror
+    http://storage.core-os.net/mirror/portage-stable/
+    http://storage.core-os.net/mirror/coreos/
+    http://distfiles.gentoo.org/
 "
 
 # Remove all .la files for non-plugin libraries.

--- a/coreos/config/make.conf.common-target
+++ b/coreos/config/make.conf.common-target
@@ -58,10 +58,10 @@ PORTAGE_BINPKG_TAR_OPTS="--checkpoint=1000"
 # Since our portage comes from version control, we redirect distfiles.
 DISTDIR="/var/lib/portage/distfiles-target"
 
-# TODO: Our mirror should be more stable since we won't discard packages.
 GENTOO_MIRRORS="
-	http://gentoo.osuosl.org/
-	https://commondatastorage.googleapis.com/chromeos-mirror/gentoo
+    http://storage.core-os.net/mirror/portage-stable/
+    http://storage.core-os.net/mirror/coreos/
+    http://distfiles.gentoo.org/
 "
 
 # Username and home directory of the shared user.


### PR DESCRIPTION
These two mirrors are generated specifically from our own overlays so
they should always include everything we need. The default Gentoo mirror
is provided simply as a sane backup.
