### PR TITLE
feat(coreos-base/update_engine): use coreos-ca-certificates

### DIFF
--- a/coreos-base/update_engine/update_engine-0.0.1-r368.ebuild
+++ b/coreos-base/update_engine/update_engine-0.0.1-r368.ebuild
@@ -1,0 +1,1 @@
+update_engine-0.0.1.ebuild

--- a/coreos-base/update_engine/update_engine-0.0.1.ebuild
+++ b/coreos-base/update_engine/update_engine-0.0.1.ebuild
@@ -2,8 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="4"
-CROS_WORKON_COMMIT="193c41ed66d25ba76e828b0715f7f80ae88eb226"
-CROS_WORKON_TREE="4e09ef237374751d99122f8225bc14a71de2c968"
+CROS_WORKON_COMMIT="08a60bd76c1a4ad8e59cf3e29b43a11c857e1bcd"
 CROS_WORKON_PROJECT="coreos/update_engine"
 CROS_WORKON_REPO="git://github.com"
 
@@ -21,7 +20,7 @@ IUSE="cros_host -delta_generator"
 LIBCHROME_VERS="180609"
 
 RDEPEND="app-arch/bzip2
-	coreos-base/chromeos-ca-certificates
+	coreos-base/coreos-ca-certificates
 	coreos-base/libchrome:${LIBCHROME_VERS}[cros-debug=]
 	coreos-base/libchromeos
 	coreos-base/metrics


### PR DESCRIPTION
stop using the chromeos ca certificates and use coreos's instead.
