### PR TITLE
make docker run directly under systemd without forking

### DIFF
--- a/app-emulation/docker/files/docker.service
+++ b/app-emulation/docker/files/docker.service
@@ -1,15 +1,15 @@
 [Service]
-Type=forking
+Type=simple
 ExecStartPre=/bin/mount --make-rprivate /
 # Enable forwarding to allow NAT to work
 # TODO: Move this to sysctl.conf
 ExecStartPre=/sbin/sysctl -w net.ipv4.ip_forward=1
 
-# HACK: for some reason docker is crashing when exiting a container when being
-# supervised by systemd. Fork out for now. Real solution should be:
-# ExecStart=/usr/bin/docker -d -D
+# Try to use this alternate way of starting docker if docker crashes for you:
+# ExecStart=/bin/bash -c "/usr/bin/nohup /usr/bin/docker -d -D &"
+# You also need to update Type above to: Type=forking
 
-ExecStart=/bin/bash -c "/usr/bin/nohup /usr/bin/docker -d -D &"
+ExecStart=/usr/bin/docker -d -D
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Docker seems to be working fine now under systemd. Some recent code changes have fixed the problems we were running into before.

What has been tested while running docker directly under systemd:
1. docker run
2. docker pull
3. docker images
4. docker rm

I've rebooted a few times and it seemed to work every single time. I've also run `docker run` a few times and I can confirm that I'm not running into either of the following problems any more:
1. failure to start lxc on the first `docker run`
2. failure to exit and cleanup properly after a docker run
3. any other similar issues
