### PR TITLE
fix(profiles): Apply the bindist flag to both the SDK and targets

### DIFF
--- a/profiles/base/make.defaults
+++ b/profiles/base/make.defaults
@@ -142,6 +142,9 @@ USE_EXPAND_HIDDEN="${USE_EXPAND_HIDDEN} CROS_WORKON_TREE"
 # Previously defined in make.conf
 USE="${USE} hardened cros_host pic pie expat -introspection -cups -openrc"
 
+# Enable bindist for both SDK and targets
+USE="${USE} bindist"
+
 # Default licenses that are accepted for ChromiumOS builds.
 # If you want to accept more, use the --accept_licenses flag
 # when running setup_board.

--- a/profiles/targets/coreos/make.defaults
+++ b/profiles/targets/coreos/make.defaults
@@ -1,7 +1,7 @@
 # Copyright (c) 2012 The Chromium OS Authors. All rights reserved.
 # Distributed under the terms of the GNU General Public License v2
 
-USE="bindist cros-debug acpi usb pam"
+USE="cros-debug acpi usb pam"
 USE="${USE} -cros_host -expat -pic -pie -cairo -X"
 USE="${USE} -acl -cracklib -gpm -ipv6 -openmp -python -sha512"
 USE="${USE} -fortran -abiword -perl -cups -poppler-data -nls"

--- a/profiles/targets/coreos/package.use.mask
+++ b/profiles/targets/coreos/package.use.mask
@@ -1,11 +1,6 @@
 # Copyright (c) 2010 The Chromium OS Authors. All rights reserved.
 # Distributed under the terms of the GNU General Public License v2
 
-# Brian Stell <bstell@chromium.org> (27 August 2010)
-# For Chromium OS enable FreeType sub-pixel anti-aliasing and bytecode
-# interpreter
-media-libs/freetype bindist
-
 # Jungshik Shin <jshin@chromium.org) (31 August 2010)
 # We don't want to generate fonts.scale when installing fonts with font.eclass
 # ( http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/eclass/font.eclass?revision=1.50&view=markup )


### PR DESCRIPTION
Previously only targets were being built with bindist but we should
build the SDK with it as well. This avoids the re-compile of openssl,
openssh, and freetype when creating a new chroot since the SDK tarballs
are already built with the bindist flag. Also turn the bindist flag back
on for freetype in the target profile, we don't need ClearType sub-pixel
rendering on our systems. :)
