### PR TITLE
feat(profiles): Add lbzip2 to base system package set

### DIFF
--- a/coreos/config/make.conf.amd64-host
+++ b/coreos/config/make.conf.amd64-host
@@ -26,7 +26,8 @@ PORTDIR_OVERLAY="
 # of the ChromiumOS set.  You can use "--select" to override this.
 EMERGE_DEFAULT_OPTS="--oneshot"
 
-# Use parallel bzip2 for portage if available
+# Use parallel bzip2 for portage
+# TODO(marineam): switch to lbzip2
 PORTAGE_BZIP2_COMMAND="pbzip2"
 PORTAGE_BUNZIP2_COMMAND="pbunzip2 --ignore-trailing-garbage=1"
 

--- a/coreos/config/make.conf.common-target
+++ b/coreos/config/make.conf.common-target
@@ -37,9 +37,9 @@ PORTDIR_OVERLAY="
 # of the ChromiumOS set.  You can use "--select" to override this.
 EMERGE_DEFAULT_OPTS="--oneshot"
 
-# Use parallel bzip2 for portage if available
-PORTAGE_BZIP2_COMMAND="pbzip2"
-PORTAGE_BUNZIP2_COMMAND="pbunzip2 --ignore-trailing-garbage=1"
+# Use parallel bzip2 for portage
+PORTAGE_BZIP2_COMMAND="lbzip2"
+PORTAGE_BUNZIP2_COMMAND="lbunzip2"
 
 FETCHCOMMAND_GS="bash -c 'BOTO_CONFIG=/home/\${PORTAGE_USERNAME}/.boto gsutil cp \"${URI}\" \"${DISTDIR}/${FILE}\"'"
 RESUMECOMMAND_GS="bash -c 'BOTO_CONFIG=/home/\${PORTAGE_USERNAME}/.boto gsutil cp \"${URI}\" \"${DISTDIR}/${FILE}\"'"

--- a/profiles/default/linux/packages
+++ b/profiles/default/linux/packages
@@ -13,3 +13,4 @@
 *sys-apps/man-pages
 *sys-apps/util-linux
 *sys-apps/efunctions
+*app-arch/lbzip2

--- a/profiles/default/linux/packages.build
+++ b/profiles/default/linux/packages.build
@@ -7,6 +7,7 @@
 
 app-arch/bzip2
 app-arch/gzip
+app-arch/lbzip2
 app-arch/tar
 app-shells/bash
 net-misc/rsync


### PR DESCRIPTION
lbzip2 is surprisingly fast and is particularly useful for dealing with
large archives and filesystem images. In a similar vein pbzip2 has been
used for handling binary packages for a while but lbzip2 seems a bit
better. Since I plan on using the heck out of lbzip2 add it to the build
and system package sets. While mucking around might as well start
swapping pbzip2 for lbzip2 for consistency's sake although it doesn't
seem to matter much for binary packages. For now we can only switch
make.conf for targets, the host make.conf can't change till everyone's
SDK has lbzip2 installed.
