### PR TITLE
fix(profiles): Move the mirror list from make.conf to profiles.

### DIFF
--- a/coreos/config/make.conf.amd64-host
+++ b/coreos/config/make.conf.amd64-host
@@ -44,12 +44,6 @@ PORTAGE_BINHOST="
     http://storage.core-os.net/coreos/sdk/${ARCH}/${COREOS_VERSION_STRING}/pkgs/
 "
 
-GENTOO_MIRRORS="
-    http://storage.core-os.net/mirror/portage-stable/
-    http://storage.core-os.net/mirror/coreos/
-    http://distfiles.gentoo.org/
-"
-
 # Remove all .la files for non-plugin libraries.
 # Remove Gentoo init files since we use upstart.
 # Remove logrotate.d files since we don't use logrotate.

--- a/coreos/config/make.conf.common-target
+++ b/coreos/config/make.conf.common-target
@@ -53,12 +53,6 @@ PORTAGE_BINPKG_TAR_OPTS="--checkpoint=1000"
 # Since our portage comes from version control, we redirect distfiles.
 DISTDIR="/var/lib/portage/distfiles-target"
 
-GENTOO_MIRRORS="
-    http://storage.core-os.net/mirror/portage-stable/
-    http://storage.core-os.net/mirror/coreos/
-    http://distfiles.gentoo.org/
-"
-
 # Username and home directory of the shared user.
 SHARED_USER_NAME="core"
 SHARED_USER_HOME="/home/core/user"

--- a/profiles/base/make.defaults
+++ b/profiles/base/make.defaults
@@ -149,3 +149,10 @@ USE="${USE} bindist"
 # If you want to accept more, use the --accept_licenses flag
 # when running setup_board.
 ACCEPT_LICENSE="* -@EULA -@CHROMEOS"
+
+# Favor our own mirrors over Gentoo's
+GENTOO_MIRRORS="
+    http://storage.core-os.net/mirror/portage-stable/
+    http://storage.core-os.net/mirror/coreos/
+    http://distfiles.gentoo.org/
+"


### PR DESCRIPTION
Another piece of migrating as much as possible into our profiles, this
should fix a current error blocking bootstrap_sdk builds.
