### PR TITLE
fix(config): Remove URL for old Google toolchain packages.

### DIFF
--- a/coreos/config/make.conf.amd64-host
+++ b/coreos/config/make.conf.amd64-host
@@ -36,11 +36,7 @@ PKGDIR="/var/lib/portage/pkgs"
 
 PORT_LOGDIR="/var/log/portage"
 
-# Our first round of binary packages!
-# legacy contains the old x86_64-cros-linux-gnu toolchain since I haven't
-# rebuilt it yet. 20130621235834 contains everything built by bootstrap_sdk
 PORTAGE_BINHOST="
-    http://storage.core-os.net/coreos/sdk/experimental/legacy/pkgs/
     http://storage.core-os.net/coreos/sdk/${ARCH}/${COREOS_VERSION_STRING}/pkgs/
 "
 


### PR DESCRIPTION
As of v9.1.0 we have our own binary toolchain packages so this is no
longer needed.

Depends on: https://github.com/coreos/manifest/pull/6
