### PR TITLE
fix(app-editors/qemacs): Fix malformed patch.

### DIFF
--- a/app-editors/qemacs/files/qemacs-0.3.2_pre20070226-tty_utf8.patch
+++ b/app-editors/qemacs/files/qemacs-0.3.2_pre20070226-tty_utf8.patch
@@ -1,10 +1,9 @@
-Gemeinsame Unterverzeichnisse: ../qemacs/fonts und ./fonts.
-Gemeinsame Unterverzeichnisse: ../qemacs/libqhtml und ./libqhtml.
-Gemeinsame Unterverzeichnisse: ../qemacs/plugin-example und ./plugin-example.
-Gemeinsame Unterverzeichnisse: ../qemacs/tests und ./tests.
-diff -u ../qemacs/tty.c ./tty.c
---- ../qemacs/tty.c	2007-02-08 00:27:33.000000000 +0100
-+++ ./tty.c	2007-02-26 15:07:41.000000000 +0100
+utf8 input in tty.c
+http://lists.gnu.org/archive/html/qemacs-devel/2004-03/msg00000.html
+http://bugs.gentoo.org/62829
+
+--- qemacs-orig/tty.c	2007-02-08 00:27:33.000000000 +0100
++++ qemacs/tty.c	2007-02-26 15:07:41.000000000 +0100
 @@ -78,7 +78,6 @@
      /* input handling */
      enum InputState input_state;


### PR DESCRIPTION
This patch uses relative paths that are rejected by newer and stricter
eclass versions. Pulled from current portage but I'm purposefully _not_
updating the ebuild as the latest texi2html which in turn pulls in a lot
of new perl dependencies and we don't even care about texi2html or the
html docs it is used to produce in the first place so bleh.
