### PR TITLE
fix(coreos-base/verity): Fix use of gcc flag not available in 4.6

### DIFF
--- a/coreos-base/verity/files/dm-verity-gcc-4.6-stack-protector.patch
+++ b/coreos-base/verity/files/dm-verity-gcc-4.6-stack-protector.patch
@@ -1,0 +1,13 @@
+diff --git a/common.mk b/common.mk
+index 058e906..9d4158a 100644
+--- a/common.mk
++++ b/common.mk
+@@ -276,7 +276,7 @@ endif
+ #  CXXFLAGS := -mahflag $(CXXFLAGS) # Prepend to the list
+ #  CXXFLAGS := $(filter-out badflag,$(CXXFLAGS)) # Filter out a value
+ # The same goes for CFLAGS.
+-COMMON_CFLAGS-gcc := -fstack-protector-strong -fvisibility=internal -ggdb3 \
++COMMON_CFLAGS-gcc := -fstack-protector-all -fvisibility=internal -ggdb3 \
+   -Wa,--noexecstack
+ COMMON_CFLAGS-clang := -fstack-protector-all -fvisibility=hidden -ggdb
+ COMMON_CFLAGS := -Wall -Werror -fno-strict-aliasing -O1 -Wformat=2

--- a/coreos-base/verity/verity-0.0.1-r76.ebuild
+++ b/coreos-base/verity/verity-0.0.1-r76.ebuild
@@ -7,7 +7,7 @@ CROS_WORKON_TREE="a54ff06d13ee681a7cb660ed14c51dcd8ef5ffdf"
 CROS_WORKON_PROJECT="chromiumos/platform/dm-verity"
 CROS_WORKON_OUTOFTREE_BUILD=1
 
-inherit cros-workon cros-au
+inherit cros-workon cros-au eutils
 
 DESCRIPTION="File system integrity image generator for Chromium OS"
 HOMEPAGE="http://www.chromium.org/"
@@ -33,6 +33,9 @@ DEPEND="${RDEPEND}
 
 src_prepare() {
 	cros-workon_src_prepare
+	# temporary fix for gcc 4.6 compatibility
+	# we don't use verity (yet) so don't bother forking the git repo yet...
+	epatch "${FILESDIR}/dm-verity-gcc-4.6-stack-protector.patch"
 }
 
 src_configure() {


### PR DESCRIPTION
Verity uses -fstack-protector-strong which was added in 4.7, use -all
instead which is available in 4.6. Dunno what impact this has but we
don't actually use it yet so _shrug_. Only a temporary fix since we
would probably want to fork verity if we use it or drop support entirely
if we decide we never will.
