### PR TITLE
fix(profiles): Add xz-utils to the system package set.

### DIFF
--- a/profiles/base/packages
+++ b/profiles/base/packages
@@ -29,6 +29,7 @@
 *app-arch/cpio
 *app-arch/gzip
 *app-arch/tar
+*app-arch/xz-utils
 *app-shells/bash
 #*dev-lang/perl
 #*dev-lang/python


### PR DESCRIPTION
It is included in system in upstream Gentoo so we should too, otherwise
there is a chance builds will fail if xz isn't installed early enough.
