### PR TITLE
fix(coreos-base/bootengine): don't hardcode ${ROOT}

### DIFF
--- a/coreos-base/bootengine/bootengine-0.0.1.ebuild
+++ b/coreos-base/bootengine/bootengine-0.0.1.ebuild
@@ -24,8 +24,11 @@ src_install() {
 	insinto /usr/lib/dracut/modules.d/
 	doins -r ${S}/dracut/80gptprio $modules_dir
 
-	chroot /build/amd64-generic dracut --no-kernel --fstab --no-compress /tmp/bootengine.cpio
+	chroot ${ROOT} dracut --force --no-kernel --fstab --no-compress /tmp/bootengine.cpio
+
+	cpio=${ROOT}/tmp/bootengine.cpio
 
 	insinto /usr/share/bootengine/
-	doins /build/amd64-generic/tmp/bootengine.cpio
+	doins ${cpio}
+	rm ${cpio}
 }

--- a/coreos-base/bootengine/bootengine-9999.ebuild
+++ b/coreos-base/bootengine/bootengine-9999.ebuild
@@ -23,8 +23,11 @@ src_install() {
 	insinto /usr/lib/dracut/modules.d/
 	doins -r ${S}/dracut/80gptprio $modules_dir
 
-	chroot /build/amd64-generic dracut --no-kernel --fstab --no-compress /tmp/bootengine.cpio
+	chroot ${ROOT} dracut --force --no-kernel --fstab --no-compress /tmp/bootengine.cpio
+
+	cpio=${ROOT}/tmp/bootengine.cpio
 
 	insinto /usr/share/bootengine/
-	doins /build/amd64-generic/tmp/bootengine.cpio
+	doins ${cpio}
+	rm ${cpio}
 }


### PR DESCRIPTION
use the ${ROOT} variable instead of hard coding our own right here.
