### PR TITLE
feat(coreos) add bootkernel to build

### DIFF
--- a/coreos-base/bootengine/bootengine-0.0.1.ebuild
+++ b/coreos-base/bootengine/bootengine-0.0.1.ebuild
@@ -18,6 +18,7 @@ SLOT="0"
 KEYWORDS="amd64 x86"
 
 DEPEND="
+	sys-apps/kexec-tools
 	sys-kernel/dracut"
 
 src_install() {

--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -104,7 +104,7 @@ RDEPEND="${RDEPEND}
 
 RDEPEND="${RDEPEND}
 	sys-apps/findutils
-	sys-apps/kexec-tools
+	sys-kernel/coreos-bootkernel
 	app-admin/sudo
 	app-admin/rsyslog
 	app-arch/gzip


### PR DESCRIPTION
This adds the bootkernel to the full system build and moves the
kexec-tools dependancy to the bootengine ebuild, where it belongs.
