### PR TITLE
fix(coreos-base/bootengine) update 9999 ebuild so that cros_workon works

### DIFF
--- a/coreos-base/bootengine/bootengine-9999.ebuild
+++ b/coreos-base/bootengine/bootengine-9999.ebuild
@@ -17,17 +17,39 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
 
 DEPEND="
+	sys-apps/kexec-tools
 	sys-kernel/dracut"
 
 src_install() {
 	insinto /usr/lib/dracut/modules.d/
 	doins -r ${S}/dracut/80gptprio $modules_dir
+}
 
-	chroot ${ROOT} dracut --force --no-kernel --fstab --no-compress /tmp/bootengine.cpio
+# We are bad, we want to get around the sandbox.  So do the creation of the
+# cpio image in pkg_postinst() where we are free to mount filesystems, chroot,
+# and other fun stuff.
+pkg_postinst() {
+	mount -t proc proc ${ROOT}/proc
+	mount --rbind /dev ${ROOT}/dev
+	mount --rbind /sys ${ROOT}/sys
+	mount --rbind /run ${ROOT}/run
 
+	# --host-only "should" mean that we only include the stuff that this build
+	# root needs.  The keyboard tables are all still being included, which we
+	# need to figure out how to remove someday.
+	chroot ${ROOT} dracut --host-only --force --no-kernel --fstab --no-compress /tmp/bootengine.cpio
+
+	umount ${ROOT}/proc
+	umount ${ROOT}/dev/pts	# trust me, it's there, unmount it.
+	umount ${ROOT}/dev
+	umount ${ROOT}/sys
+	umount ${ROOT}/run
+
+	# as we are not in src_install() insinto and doins do not work here, so
+	# manually copy the file around
 	cpio=${ROOT}/tmp/bootengine.cpio
-
-	insinto /usr/share/bootengine/
-	doins ${cpio}
+	chmod 644 ${cpio}
+	mkdir ${ROOT}/usr/share/bootengine/
+	cp ${cpio} ${ROOT}/usr/share/bootengine/
 	rm ${cpio}
 }


### PR DESCRIPTION
This was broken due to the changes in the "stable" bootengine package
and I forgot to update this version as well, sorry.
