### PR TITLE
feat(eclass/cros-kernel2.eclass) provide stable symlink for cros-bootker...

### DIFF
--- a/eclass/cros-kernel2.eclass
+++ b/eclass/cros-kernel2.eclass
@@ -464,6 +464,8 @@ cros-kernel2_src_install() {
 	if [ ! -e "${D}/boot/vmlinuz" ]; then
 		if [ "$(get_boot_kernel)" = "false" ]; then
 			ln -sf "vmlinuz-${version}" "${D}/boot/vmlinuz" || die
+		else
+			ln -sf "vmlinuz-${version}" "${D}/boot/vmlinuz-boot_kernel" || die
 		fi
 	fi
 


### PR DESCRIPTION
...nel

It is called /boot/vmlinuz-boot_kernel
