### PR TITLE
fix(profiles): Enable lbzip2 for both SDK and targets, move to profiles

### DIFF
--- a/coreos/config/make.conf.amd64-host
+++ b/coreos/config/make.conf.amd64-host
@@ -26,11 +26,6 @@ PORTDIR_OVERLAY="
 # of the ChromiumOS set.  You can use "--select" to override this.
 EMERGE_DEFAULT_OPTS="--oneshot"
 
-# Use parallel bzip2 for portage
-# TODO(marineam): switch to lbzip2
-PORTAGE_BZIP2_COMMAND="pbzip2"
-PORTAGE_BUNZIP2_COMMAND="pbunzip2 --ignore-trailing-garbage=1"
-
 # Where to store built packages.
 PKGDIR="/var/lib/portage/pkgs"
 

--- a/coreos/config/make.conf.common-target
+++ b/coreos/config/make.conf.common-target
@@ -37,10 +37,6 @@ PORTDIR_OVERLAY="
 # of the ChromiumOS set.  You can use "--select" to override this.
 EMERGE_DEFAULT_OPTS="--oneshot"
 
-# Use parallel bzip2 for portage
-PORTAGE_BZIP2_COMMAND="lbzip2"
-PORTAGE_BUNZIP2_COMMAND="lbunzip2"
-
 FETCHCOMMAND_GS="bash -c 'BOTO_CONFIG=/home/\${PORTAGE_USERNAME}/.boto gsutil cp \"${URI}\" \"${DISTDIR}/${FILE}\"'"
 RESUMECOMMAND_GS="bash -c 'BOTO_CONFIG=/home/\${PORTAGE_USERNAME}/.boto gsutil cp \"${URI}\" \"${DISTDIR}/${FILE}\"'"
 

--- a/profiles/default/linux/make.defaults
+++ b/profiles/default/linux/make.defaults
@@ -48,3 +48,7 @@ LDFLAGS="-Wl,-O1 -Wl,--as-needed"
 # http://archives.gentoo.org/gentoo-dev/msg_dc705dc2c1a45e18a85aa62e8fb17009.xml
 # Build kernel modules from linux-mod by default:
 USE="${USE} modules"
+
+# Use parallel bzip2 for binary packages
+PORTAGE_BZIP2_COMMAND="lbzip2"
+PORTAGE_BUNZIP2_COMMAND="lbunzip2"


### PR DESCRIPTION
It has been long enough since adding lbzip2 to the system set, time to
put it to work for all our binary package needs!
