### PR TITLE
fix(dev-db/etcd): Handle missing ec2 user-data correctly.

### DIFF
--- a/dev-db/etcd/files/coreos-c10n
+++ b/dev-db/etcd/files/coreos-c10n
@@ -9,7 +9,7 @@ ETCD_BOOTSTRAP="/var/run/etcd/bootstrap.config"
 /usr/bin/block-until-url $C10N_ENDPOINT
 /usr/bin/block-until-url $META_URL
 
-USER_DATA=$(curl -s $META_URL/user-data)
+USER_DATA=$(curl -s --fail $META_URL/user-data)
 if [ $? -eq 0 ] && [ ! -z "$USER_DATA" ]; then
         URL=$USER_DATA
 


### PR DESCRIPTION
Important notice to all using curl: by default a 404 is not an error!

I noticed that instances created without any user data were attempting
to connect to a _lot_ of random IP addresses and failing. After
attempting the curl command c10n uses to fetch user data it would seem
we have lots of virtual machines using the following as a secret key:

```
<?xml version="1.0" encoding="iso-8859-1"?>
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
  <title>404 - Not Found</title>
 </head>
 <body>
  <h1>404 - Not Found</h1>
 </body>
</html>
```

ᕙ(⇀‸↼‶)ᕗ

The --fail option is required for curl to behave responsibly.
