### PR TITLE
feat(eclass/git-2): just fetch everything

### DIFF
--- a/eclass/git-2.eclass
+++ b/eclass/git-2.eclass
@@ -504,7 +504,7 @@ git-2_migrate_repository() {
 		debug-print "${FUNCNAME}: working in bare repository for \"${EGIT_DIR}\""
 		EGIT_LOCAL_OPTIONS+="${EGIT_OPTIONS} --bare"
 		MOVE_COMMAND="git clone -l -s -n ${EGIT_DIR// /\\ }"
-		EGIT_UPDATE_CMD="git fetch -t -f -u origin ${EGIT_BRANCH}:${EGIT_BRANCH}"
+		EGIT_UPDATE_CMD="git fetch --all -t -f -u origin ${EGIT_BRANCH}:${EGIT_BRANCH}"
 		UPSTREAM_BRANCH="${EGIT_BRANCH}"
 	else
 		debug-print "${FUNCNAME}: working in bare repository for non-bare \"${EGIT_DIR}\""


### PR DESCRIPTION
This solves the problem with our kernel not having the right ref because we
use different branches per version. I really don't know why we wouldn't just
default to this.
