### PR TITLE
fix(virtual/linux-sources): Only install coreos-kernel on targets.

### DIFF
--- a/virtual/linux-sources/linux-sources-2-r1.ebuild
+++ b/virtual/linux-sources/linux-sources-2-r1.ebuild
@@ -9,9 +9,8 @@ HOMEPAGE="http://www.coreos.com"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="amd64 arm x86"
-IUSE="-kernel_next -kernel_sources"
+IUSE="cros_host"
 
 RDEPEND="
-	kernel_next? ( sys-kernel/coreos-kernel-next[kernel_sources=] )
-	!kernel_next? ( sys-kernel/coreos-kernel[kernel_sources=] )
+	!cros_host? ( sys-kernel/coreos-kernel )
 "


### PR DESCRIPTION
We don't have a valid kernel (or use-case to have one) for "cros_host"
(the SDK) so just fake it. Also remove some unused flags.

This change prevents the latest kmod ebuild from pulling in
coreos-kernel, bootengine, and friends into the SDK.
