### PR TITLE
fix(app-emulation/docker): restart on crash

### DIFF
--- a/app-emulation/docker/files/docker.service
+++ b/app-emulation/docker/files/docker.service
@@ -11,5 +11,8 @@ ExecStartPre=/sbin/sysctl -w net.ipv4.ip_forward=1
 
 ExecStart=/usr/bin/docker -d -D
 
+Restart=always
+RestartSec=1
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
docker has been known to crash from time to time in odd situations. Auto
restart docker 1 second after an unexpected exit so that people can go
about their business.

Thanks to dsal & fkautz in #coreos
