### PR TITLE
fix(dev-db/etcd): Switch server connection back to public address.

### DIFF
--- a/dev-db/etcd/files/etcd-bootstrap
+++ b/dev-db/etcd/files/etcd-bootstrap
@@ -16,7 +16,7 @@ BOOTSTRAP="/var/run/etcd/bootstrap.config"
 
 [ ! -e $BOOTSTRAP ] && echo bootstrap config missing && exit 1
 
-CLUSTER_ARGS="-n $MY_IP -c 0.0.0.0:4001 -s 0.0.0.0:7001"
+CLUSTER_ARGS="-n $MY_IP -c 0.0.0.0:4001 -s $MY_IP:7001"
 
 # strip blank lines
 IPS=$(grep -v $MY_IP $BOOTSTRAP|grep -v '^\n$' |sed 's/$/:7001/'|tr '\n' ','|sed 's/^,//'|sed 's/,$//')


### PR DESCRIPTION
As part of 20b5cfc9 I convinced @philips to switch both addresses to
0.0.0.0 instead of just the client one as he intended. Well now etcd can
no longer form clusters with more than two nodes and I'm assuming this
change is at fault. Switching the server address back in hopes that
things work better.
