### PR TITLE
fix(dev-db/etcd): fixup listening IP

### DIFF
--- a/dev-db/etcd/etcd-0.1.1-r3.ebuild
+++ b/dev-db/etcd/etcd-0.1.1-r3.ebuild
@@ -9,7 +9,7 @@ EAPI=4
 CROS_WORKON_PROJECT="coreos/etcd"
 CROS_WORKON_LOCALNAME="etcd"
 CROS_WORKON_REPO="git://github.com"
-CROS_WORKON_COMMIT="7b289043c7beced434be4334fb909ba0b16b57b1" # hash for tag v0.1.1
+CROS_WORKON_COMMIT="32cf8ddfde3adb068635b2297169a91364ca7606" # hash for tag v0.1.1 + listen fixes
 inherit toolchain-funcs cros-workon systemd
 
 DESCRIPTION="etcd"

--- a/dev-db/etcd/files/etcd-bootstrap
+++ b/dev-db/etcd/files/etcd-bootstrap
@@ -16,7 +16,7 @@ BOOTSTRAP="/var/run/etcd/bootstrap.config"
 
 [ ! -e $BOOTSTRAP ] && echo bootstrap config missing && exit 1
 
-CLUSTER_ARGS="-n $MY_IP -c 0.0.0.0:4001 -s 0.0.0.0:7001"
+CLUSTER_ARGS="-n $MY_IP -c $MY_IP:4001 -cl 0.0.0.0 -s $MY_IP:7001 -sl 0.0.0.0"
 
 # strip blank lines
 IPS=$(grep -v $MY_IP $BOOTSTRAP|grep -v '^\n$' |sed 's/$/:7001/'|tr '\n' ','|sed 's/^,//'|sed 's/,$//')


### PR DESCRIPTION
This fixes the listening ips problem that keeps people from hitting
127.0.0.1 as reported by users.
