### PR TITLE
fix(app-crypt/sbsigntool) fix cross-build for sbsigntool

### DIFF
--- a/app-crypt/sbsigntool/files/no_docs.patch
+++ b/app-crypt/sbsigntool/files/no_docs.patch
@@ -1,0 +1,53 @@
+diff --git a/Makefile.am b/Makefile.am
+index d347e9b3..cc1c29b1 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,2 +1,2 @@
+ 
+-SUBDIRS = lib/ccan src docs tests
++SUBDIRS = lib/ccan src tests
+diff --git a/Makefile.in b/Makefile.in
+index 57e7c4a3..584d2616 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -225,7 +225,7 @@ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+ uuid_CFLAGS = @uuid_CFLAGS@
+ uuid_LIBS = @uuid_LIBS@
+-SUBDIRS = lib/ccan src docs tests
++SUBDIRS = lib/ccan src tests
+ all: config.h
+ 	$(MAKE) $(AM_MAKEFLAGS) all-recursive
+ 
+diff --git a/configure b/configure
+index 73198f17..94408bba 100755
+--- a/configure
++++ b/configure
+@@ -5517,7 +5517,7 @@ CPPFLAGS="$CPPFLAGS_save"
+ EFI_CPPFLAGS=$EFI_CPPFLAGS
+ 
+ 
+-ac_config_files="$ac_config_files Makefile src/Makefile lib/ccan/Makefile docs/Makefile tests/Makefile"
++ac_config_files="$ac_config_files Makefile src/Makefile lib/ccan/Makefile tests/Makefile"
+ 
+ cat >confcache <<\_ACEOF
+ # This file is a shell script that caches the results of configure
+@@ -6249,7 +6249,6 @@ do
+     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
+     "src/Makefile") CONFIG_FILES="$CONFIG_FILES src/Makefile" ;;
+     "lib/ccan/Makefile") CONFIG_FILES="$CONFIG_FILES lib/ccan/Makefile" ;;
+-    "docs/Makefile") CONFIG_FILES="$CONFIG_FILES docs/Makefile" ;;
+     "tests/Makefile") CONFIG_FILES="$CONFIG_FILES tests/Makefile" ;;
+ 
+   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
+diff --git a/configure.ac b/configure.ac
+index 0d8f0bbd..fb2b6c4f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -74,5 +74,5 @@ CPPFLAGS="$CPPFLAGS_save"
+ AC_SUBST(EFI_CPPFLAGS, $EFI_CPPFLAGS)
+ 
+ AC_CONFIG_FILES([Makefile src/Makefile lib/ccan/Makefile]
+-		[docs/Makefile tests/Makefile])
++		[tests/Makefile])
+ AC_OUTPUT

--- a/app-crypt/sbsigntool/sbsigntool-0.6-r1.ebuild
+++ b/app-crypt/sbsigntool/sbsigntool-0.6-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2013 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: /var/cvsroot/gentoo-x86/app-crypt/sbsigntool/sbsigntool-0.6.ebuild,v 1.3 2013/08/28 11:17:16 ago Exp $
+
+EAPI="4"
+inherit eutils
+
+DESCRIPTION="Utilities for signing and verifying files for UEFI Secure Boot"
+HOMEPAGE="http://packages.ubuntu.com/quantal/sbsigntool"
+SRC_URI="https://launchpad.net/ubuntu/+archive/primary/+files/${PN}_${PV}.orig.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="amd64 x86"
+IUSE=""
+
+RDEPEND="dev-libs/openssl
+	sys-apps/util-linux"
+DEPEND="${RDEPEND}
+	sys-apps/help2man
+	sys-boot/gnu-efi
+	virtual/pkgconfig"
+
+src_prepare() {
+	local iarch
+	case ${ARCH} in
+		ia64)  iarch=ia64 ;;
+		x86)   iarch=ia32 ;;
+		amd64) iarch=x86_64 ;;
+		*)     die "unsupported architecture: ${ARCH}" ;;
+	esac
+	sed -i "/^EFI_ARCH=/s:=.*:=${iarch}:" configure || die
+	sed -i 's/-m64$/& -march=x86-64/' tests/Makefile.in || die
+
+	# stupid cross-compile nonsense...
+	epatch "${FILESDIR}"/no_docs.patch
+}


### PR DESCRIPTION
As the documentation isn't being built, don't try to install it.  Fix
this by just not ever going into the doc/ subdirectory.  I'm sure
there's a "proper" fix for this with the HELP2MAN stuff, but it really
doesn't matter, so this work-around is good enough for now.
