### PR TITLE
fix(package.accept_keywords) add ~amd64 to efitools and gnu-efi

### DIFF
--- a/profiles/default/linux/package.accept_keywords
+++ b/profiles/default/linux/package.accept_keywords
@@ -1,3 +1,4 @@
+# Copyright (c) 2009 The Chromium OS Authors. All rights reserved.
 # Copyright (c) 2013 The CoreOS Authors. All rights reserved.
 # Distributed under the terms of the GNU General Public License v2
 


### PR DESCRIPTION
This is required for these packages to build as upstream has not
stabilized them yet, and it's doubtful that will happen any year soon...
