### PR TITLE
fix(profiles): Update to gentoolkit-0.3.0.8

### DIFF
--- a/profiles/default/linux/package.accept_keywords
+++ b/profiles/default/linux/package.accept_keywords
@@ -104,3 +104,6 @@
 # efitools and dependency libraries for signing kernel images
 >=sys-boot/gnu-efi-3.0u		~amd64
 >=app-crypt/efitools-1.4.1-r2	~amd64
+
+# Fixes euse: https://bugs.gentoo.org/show_bug.cgi?id=473760
+=app-portage/gentoolkit-0.3.0.8


### PR DESCRIPTION
This will be helpful when I get back to my old project of rebasing our
portage profiles on upstream Gentoo's profiles.
