### PR TITLE
fix(dev-db/etcd): listen on 0.0.0.0 on non-ec2 types

### DIFF
--- a/dev-db/etcd/files/etcd-bootstrap
+++ b/dev-db/etcd/files/etcd-bootstrap
@@ -2,7 +2,7 @@
 
 VIRT=$(coreos-detect-virt)
 STATE=/var/lib/etcd
-DEFAULT_ARGS="-d $STATE -f"
+DEFAULT_ARGS="-d $STATE -f -cl 0.0.0.0"
 
 if [ "${VIRT}" != "ec2" ]; then
 	echo "Detected environment \"${VIRT}\", just starting solo master..."
@@ -16,7 +16,7 @@ BOOTSTRAP="/var/run/etcd/bootstrap.config"
 
 [ ! -e $BOOTSTRAP ] && echo bootstrap config missing && exit 1
 
-CLUSTER_ARGS="-n $MY_IP -c $MY_IP:4001 -cl 0.0.0.0 -s $MY_IP:7001 -sl 0.0.0.0"
+CLUSTER_ARGS="-n $MY_IP -c $MY_IP:4001 -s $MY_IP:7001 -sl 0.0.0.0"
 
 # strip blank lines
 IPS=$(grep -v $MY_IP $BOOTSTRAP|grep -v '^\n$' |sed 's/$/:7001/'|tr '\n' ','|sed 's/^,//'|sed 's/,$//')


### PR DESCRIPTION
This change makes it possible to access etcd from inside a docker container.
