### PR TITLE
fix(update-engine): respect the diskless parameters

### DIFF
--- a/coreos-base/update_engine/files/update-engine-reboot-manager.service
+++ b/coreos-base/update_engine/files/update-engine-reboot-manager.service
@@ -1,10 +1,7 @@
 [Unit]
-Description=Update Engine
-ConditionVirtualization=!container
+PartOf=update-engine.service
+Description=Update Engine Reboot Manager
 
 [Service]
 ExecStart=/usr/sbin/update_engine_reboot_manager
 Restart=always
-
-[Install]
-WantedBy=multi-user.target

--- a/coreos-base/update_engine/files/update-engine.service
+++ b/coreos-base/update_engine/files/update-engine.service
@@ -1,6 +1,9 @@
 [Unit]
 Description=Update Engine
 ConditionVirtualization=!container
+ConditionKernelCommandLine=!coreos.diskless
+ConditionKernelCommandLine=!coreos.statediskonly
+Wants=update-engine-reboot-manager.service
 
 [Service]
 Type=dbus


### PR DESCRIPTION
update engine shouldn't run when we are diskless (for now)
