### PR TITLE
fix(sys-kernel/coreos-kernel): Fix boot on new ec2 hardware.

### DIFF
--- a/sys-kernel/coreos-kernel/coreos-kernel-3.10.10-r5.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-3.10.10-r5.ebuild
@@ -3,7 +3,7 @@
 # $Header: /var/cvsroot/gentoo-x86/sys-kernel/vanilla-sources/vanilla-sources-3.7.5.ebuild,v 1.1 2013/01/28 13:18:54 ago Exp $
 
 EAPI=4
-CROS_WORKON_COMMIT="a50da2c50fe120e7ff58019f791c679ac5e8ac29"
+CROS_WORKON_COMMIT="cf4b416989fd5d93b72a5ad5c7c683880652b3fd"
 CROS_WORKON_REPO="git://github.com"
 CROS_WORKON_PROJECT="coreos/linux"
 CROS_WORKON_LOCALNAME="linux"


### PR DESCRIPTION
Cherry-pick edb6f29464afc65fc73767540b854abf63ae7144 from upstream:
  crypto: xor - Check for osxsave as well as avx in crypto/xor

This fixes booting with old versions of Xen running on new CPUs.
