### PR TITLE
fix(config): Fall back to the current SDK version for target packages.

### DIFF
--- a/coreos/config/make.conf.amd64-target
+++ b/coreos/config/make.conf.amd64-target
@@ -15,6 +15,7 @@ source make.conf.common
 # TODO: set $BOARD in make.conf.board_setup and use it
 PORTAGE_BINHOST="
     http://storage.core-os.net/coreos/amd64-generic/${COREOS_VERSION_STRING}/pkgs/
+    http://storage.core-os.net/coreos/amd64-generic/${COREOS_SDK_VERSION}/pkgs/
 "
 
 # Recommended MARCH_TUNE, CFLAGS, etc.


### PR DESCRIPTION
This avoids loosing access to binary packages between tagging a new
version and finishing the build. The SDK's make.conf already does this.
