### PR TITLE
fix(cros-workon.eclass): Do not add -clang to CFLAGS

### DIFF
--- a/eclass/cros-workon.eclass
+++ b/eclass/cros-workon.eclass
@@ -503,13 +503,6 @@ cros-workon_src_configure() {
 	else
 		default
 	fi
-	local p
-	for p in "${CROS_WORKON_PROJECT[@]}"; do
-		if [[ ${p} == chromiumos/platform/* ]]; then
-			append-flags -clang
-			break
-		fi
-	done
 }
 
 cw_emake() {


### PR DESCRIPTION
Not sure how this managed to work in the past, perhaps the test for
using Google's common.mk used to always fail but now works properly?
In any case, we don't use clang any more.
