### PR TITLE
feat(profiles): Add coreos/amd64/usr profile.

### DIFF
--- a/profiles/coreos/amd64/usr/parent
+++ b/profiles/coreos/amd64/usr/parent
@@ -1,0 +1,4 @@
+..
+portage-stable:arch/amd64/no-multilib
+portage-stable:features/64bit-native
+:coreos/targets/usr

--- a/profiles/coreos/amd64/usr/use.force
+++ b/profiles/coreos/amd64/usr/use.force
@@ -1,0 +1,2 @@
+# We don't do multilib.
+-multilib

--- a/profiles/coreos/targets/generic/make.defaults
+++ b/profiles/coreos/targets/generic/make.defaults
@@ -36,3 +36,6 @@ PROD_INSTALL_MASK="${INSTALL_MASK}
   /usr/share/readline
   /usr/src
 "
+
+# No suffix for 'generic' (use base, not base-usr)
+COREOS_DISK_LAYOUT_SUFFIX=""

--- a/profiles/coreos/targets/usr/make.defaults
+++ b/profiles/coreos/targets/usr/make.defaults
@@ -1,0 +1,8 @@
+# Copyright (c) 2014 The CoreOS Authors. All rights reserved.
+# Distributed under the terms of the GNU General Public License v2
+
+# Enable tweaks to install everything under /usr
+USE="symlink-usr"
+
+# Append -usr to disk layout names (use base-usr, not base)
+COREOS_DISK_LAYOUT_SUFFIX="-usr"

--- a/profiles/coreos/targets/usr/parent
+++ b/profiles/coreos/targets/usr/parent
@@ -1,0 +1,1 @@
+:coreos/targets/generic


### PR DESCRIPTION
This profile enables the symlink-usr USE flag and target profiles have a
new variable COREOS_DISK_LAYOUT_SUFFIX that allows the profile to switch
to a different set of disk layouts. By default no suffix is used but the
usr profile uses layouts with the suffix "-usr" such as "base-usr".
