### PR TITLE
fix(make.conf): Don't share binary packages between boards.

### DIFF
--- a/coreos/config/make.conf.amd64-target
+++ b/coreos/config/make.conf.amd64-target
@@ -12,12 +12,11 @@ source make.conf.board_setup
 # Common settings across all board targets.
 source make.conf.common
 
-# TODO: set $BOARD in make.conf.board_setup and use it
 PORTAGE_BINHOST="
-    http://storage.core-os.net/coreos/amd64-generic/${COREOS_VERSION_STRING}/pkgs/
-    http://storage.core-os.net/coreos/amd64-generic/${COREOS_VERSION_STRING}/toolchain/
-    http://storage.core-os.net/coreos/amd64-generic/${COREOS_SDK_VERSION}/pkgs/
-    http://storage.core-os.net/coreos/amd64-generic/${COREOS_SDK_VERSION}/toolchain/
+    http://storage.core-os.net/coreos/${BOARD_USE}/${COREOS_VERSION_STRING}/pkgs/
+    http://storage.core-os.net/coreos/${BOARD_USE}/${COREOS_VERSION_STRING}/toolchain/
+    http://storage.core-os.net/coreos/${BOARD_USE}/${COREOS_SDK_VERSION}/pkgs/
+    http://storage.core-os.net/coreos/${BOARD_USE}/${COREOS_SDK_VERSION}/toolchain/
 "
 
 # Recommended MARCH_TUNE, CFLAGS, etc.


### PR DESCRIPTION
Although it'd be nice to re-use packages for experimental boards that
may only have a few differences from amd64-generic there is a bug in
some ebuilds and portage that break sharing binary packages between
different values of $ROOT. This prevents that from happening by
accident.

https://bugs.gentoo.org/show_bug.cgi?id=490014
