### PR TITLE
fix(sys-kernel/coreos-kernel): Fix initramfs in /usr builds.

### DIFF
--- a/eclass/cros-kernel2.eclass
+++ b/eclass/cros-kernel2.eclass
@@ -184,7 +184,9 @@ cros-kernel2_src_compile() {
 
 	local bootengine_lib=$(get_bootengine_lib)
 	if [[ -n "${bootengine_lib}" ]]; then
-		mv "${bootengine_root}/lib" "${bootengine_root}/${bootengine_lib}"
+		mkdir -p "${bootengine_root}/${bootengine_lib%/*}" || die
+		mv "${bootengine_root}/lib" \
+			"${bootengine_root}/${bootengine_lib}" || die
 	fi
 	update_bootengine_cpio "${bootengine_root}"
 


### PR DESCRIPTION
Properly handle when /lib in bootengine is a symlink to /usr/lib64 in
addition to the /lib64. mv needs /usr to exist first :)
