### PR TITLE
fix(sys-kernel/coreos-kernel): Fix initrd in non-usr images.

### DIFF
--- a/eclass/cros-kernel2.eclass
+++ b/eclass/cros-kernel2.eclass
@@ -184,7 +184,7 @@ cros-kernel2_src_compile() {
 
 	local bootengine_lib=$(get_bootengine_lib)
 	if [[ -n "${bootengine_lib}" ]]; then
-		mkdir -p "${bootengine_root}/${bootengine_lib%/*}" || die
+		mkdir -p "$(dirname "${bootengine_root}/${bootengine_lib}")" || die
 		mv "${bootengine_root}/lib" \
 			"${bootengine_root}/${bootengine_lib}" || die
 	fi


### PR DESCRIPTION
My fix for /usr broke the normal images because my bash hacking was
overly simplistic. Use dirname to ensure the right thing happens.
