### PR TITLE
fix(app-admin/coreinit): Switch to new 'stable' ebuild.

### DIFF
--- a/app-admin/coreinit/coreinit-0.0.1-r1.ebuild
+++ b/app-admin/coreinit/coreinit-0.0.1-r1.ebuild
@@ -1,0 +1,1 @@
+coreinit-9999.ebuild

--- a/app-admin/coreinit/coreinit-9999.ebuild
+++ b/app-admin/coreinit/coreinit-9999.ebuild
@@ -1,15 +1,19 @@
-#
-# Copyright (c) 2011 The Chromium OS Authors. All rights reserved.
-# Copyright (c) 2013 CoreOS, Inc.. All rights reserved.
+# Copyright (c) 2014 CoreOS, Inc.. All rights reserved.
 # Distributed under the terms of the GNU General Public License v2
-# $Header:$
-#
 
 EAPI=4
 CROS_WORKON_PROJECT="coreos/coreinit"
 CROS_WORKON_LOCALNAME="coreinit"
 CROS_WORKON_REPO="git://github.com"
-inherit toolchain-funcs cros-workon systemd
+
+if [[ "${PV}" == 9999 ]]; then
+	KEYWORDS="~amd64"
+else
+	CROS_WORKON_COMMIT="02daf08f4ae548ad430d4e5084dc3b0de1138221"
+	KEYWORDS="amd64"
+fi
+
+inherit cros-workon systemd
 
 DESCRIPTION="coreinit"
 HOMEPAGE="https://github.com/coreos/coreinit"
@@ -17,18 +21,17 @@ SRC_URI=""
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64"
 IUSE=""
 
 DEPEND=">=dev-lang/go-1.1"
 
 src_compile() {
-	./build
+	./build || die
 }
 
 src_install() {
-	dobin ${S}/coreinit
-	dobin ${S}/corectl
+	dobin ${S}/bin/coreinit
+	dobin ${S}/bin/corectl
 
 	systemd_dounit "${FILESDIR}"/${PN}.service
 	systemd_enable_service multi-user.target ${PN}.service


### PR DESCRIPTION
Depending on live ebuilds is potentially flaky, time to start bumping
manually. Also fix the build, the path to the built binaries changed.
