### PR TITLE
fix(fleet): do not enable by default

### DIFF
--- a/app-admin/fleet/fleet-9999.ebuild
+++ b/app-admin/fleet/fleet-9999.ebuild
@@ -34,5 +34,4 @@ src_install() {
 	dobin ${S}/bin/fleetctl
 
 	systemd_dounit "${FILESDIR}"/${PN}.service
-	systemd_enable_service multi-user.target ${PN}.service
 }


### PR DESCRIPTION
This is causing fleet to always start.
