### PR TITLE
fix(sys-kernel/bootengine): Fix KEYWORDS

### DIFF
--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -21,7 +21,6 @@ SRC_URI=""
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
 
 DEPEND="
 	app-arch/gzip


### PR DESCRIPTION
Screwed this up in 8a6339 :(
