### PR TITLE
fix(sys-apps/systemd) allow booting without /etc/os-release

### DIFF
--- a/sys-apps/systemd/files/handle-empty-etc-os-release.patch
+++ b/sys-apps/systemd/files/handle-empty-etc-os-release.patch
@@ -1,0 +1,25 @@
+From foo@baz Wed Mar 12 23:13:38 +0000
+Date: Wed, 12 Mar 2014 23:13:38 +0000
+From: Greg Kroah-Hartman <greg@kroah.com>
+Subject: Handle empty /etc/os-release
+
+systemd uses /etc/os-release as a "flag" file to see if the filesystem
+really is an operating system image or not.  As we "know" we will always
+boot a valid filesystem, and we want to be able to handle an empty /etc
+directory (tmpfiles will recreate it, it is a symlink) just comment out
+the check and move on with our lives.
+
+
+diff --git a/src/core/dbus-manager.c b/src/core/dbus-manager.c
+index 30f28b6e2cd6..a270834f47d8 100644
+--- a/src/core/dbus-manager.c
++++ b/src/core/dbus-manager.c
+@@ -1133,7 +1133,7 @@ static int method_switch_root(sd_bus *bus, sd_bus_message *message, void *userda
+ 
+         /* Safety check */
+         if (isempty(init)) {
+-                if (! path_is_os_tree(root))
++                if (0)
+                         return sd_bus_error_setf(error, SD_BUS_ERROR_INVALID_ARGS, "Specified switch root path %s does not seem to be an OS tree. /etc/os-release is missing.", root);
+         } else {
+                 _cleanup_free_ char *p = NULL;

--- a/sys-apps/systemd/systemd-211-r1.ebuild
+++ b/sys-apps/systemd/systemd-211-r1.ebuild
@@ -105,6 +105,10 @@ KEYWORDS=
 fi
 
 src_prepare() {
+	# CoreOs specific hacks^Wfeatures
+	epatch "${FILESDIR}"/211-handle-empty-etc-os-release.patch
+
+	# upstream fixes not yet in the release
 	epatch "${FILESDIR}"/211-tmpfiles.patch
 
 if [[ ${PV} == *9999 ]]; then


### PR DESCRIPTION
systemd will not boot if /etc/os-release is not present.

We "know" better, and can recover from a lost /etc/ directory, so patch
out the test.  This is only for "real" booting, not for nspawn
containers at this point in time as we aren't booting full system images
that way.  Yet.
