### PR TITLE
fix(sys-apps/systemd): Fix systemd build during SDK bootstrap.

### DIFF
--- a/sys-apps/systemd/systemd-211-r3.ebuild
+++ b/sys-apps/systemd/systemd-211-r3.ebuild
@@ -91,12 +91,15 @@ DEPEND="${COMMON_DEPEND}
 	python? ( dev-python/lxml[${PYTHON_USEDEP}] )
 	test? ( >=sys-apps/dbus-1.6.8-r1:0 )"
 
-if [[ ${PV} == *9999 ]]; then
+# Pull in docbook to rebuild man pages since we are patching them
 DEPEND="${DEPEND}
 	app-text/docbook-xml-dtd:4.2
 	app-text/docbook-xml-dtd:4.5
 	app-text/docbook-xsl-stylesheets
-	dev-libs/libxslt:0
+	dev-libs/libxslt:0"
+
+if [[ ${PV} == *9999 ]]; then
+DEPEND="${DEPEND}
 	dev-libs/gobject-introspection
 	>=dev-libs/libgcrypt-1.4.5:0"
 


### PR DESCRIPTION
Since we have started patching the man pages we need to pull in docbook
and xslt to generate fresh ones. Doesn't impact other builds since
docbook is only missing early in the bootstrap process.
