### PR TITLE
Update coreos-0.0.1.ebuild

### DIFF
--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -109,6 +109,7 @@ RDEPEND="${RDEPEND}
 	coreos-base/coretest
 	net-analyzer/nmap
 	net-firewall/iptables
+	net-libs/libmicrohttpd
 	net-misc/bridge-utils
 	net-misc/rsync
 	net-misc/tlsdate


### PR DESCRIPTION
add net-libs/libmicrohttpd for systemd journald gateway, fixes #495
