### PR TITLE
fix(profiles): Update to openssl-1.0.1g

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -90,3 +90,7 @@ dev-util/checkbashisms
 
 # this version does not segfault when a user isn't in sudoers
 =app-admin/sudo-1.8.10_p2
+
+# Security update, CVE-2014-0160
+# https://bugs.gentoo.org/show_bug.cgi?id=507074
+=dev-libs/openssl-1.0.1g


### PR DESCRIPTION
Upstream hasn't finished marking the new version stable yet.
