### PR TITLE
fix(sys-apps/systemd): Stabilize linux headers 3.13 for systemd

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -97,3 +97,8 @@ dev-util/checkbashisms
 
 # Includes fix for checking mount status of loop devices
 =sys-fs/btrfs-progs-3.14_pre20140414
+
+# Current systemd git requires >= 3.10 to build,
+# use 3.13 since Gentoo is starting to stabilize that one:
+# https://bugs.gentoo.org/show_bug.cgi?id=507096
+=sys-kernel/linux-headers-3.13

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -78,15 +78,13 @@ PDEPEND=">=sys-apps/dbus-1.6.8-r1:0
 	policykit? ( sys-auth/polkit )
 	!vanilla? ( sys-apps/gentoo-systemd-integration )"
 
-# Newer linux-headers needed by ia64, bug #480218
 DEPEND="${COMMON_DEPEND}
 	app-arch/xz-utils:0
 	dev-util/gperf
 	>=dev-util/intltool-0.50
 	>=sys-devel/binutils-2.23.1
 	>=sys-devel/gcc-4.6
-	>=sys-kernel/linux-headers-${MINKV}
-	ia64? ( >=sys-kernel/linux-headers-3.9 )
+	>=sys-kernel/linux-headers-3.13
 	virtual/pkgconfig
 	doc? ( >=dev-util/gtk-doc-1.18 )
 	python? ( dev-python/lxml[${PYTHON_USEDEP}] )


### PR DESCRIPTION
The currently systemd git only compiles against 3.10 headers or later.
Looks like upstream Gentoo is going to stabilize 3.13 so go ahead and
do jump ahead on that to make testing systemd easier.

Depends on https://github.com/coreos/portage-stable/pull/107

This should not be merged until after the first beta release just to avoid unnecessary risk.
