### PR TITLE
add open-vm-tools

### DIFF
--- a/app-emulation/open-vm-tools/files/network
+++ b/app-emulation/open-vm-tools/files/network
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+#
+# net.eth0, net.eth1, network, wicd, NetworkManager
+service="net.eth0"
+
+if ! rc-service -e ${service}
+then
+	service="network"
+fi
+
+case "$1" in
+	suspend-vm)
+		rc-service ${service} stop
+		;;
+	resume-vm)
+		rc-service ${service} start
+		;;
+	*)
+		;;
+esac
+

--- a/app-emulation/open-vm-tools/files/open-vm-tools.confd
+++ b/app-emulation/open-vm-tools/files/open-vm-tools.confd
@@ -1,0 +1,2 @@
+# Set this to no to disable drag and drop (and vmblock) loading.
+VM_DRAG_AND_DROP="yes"

--- a/app-emulation/open-vm-tools/files/open-vm-tools.desktop
+++ b/app-emulation/open-vm-tools/files/open-vm-tools.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Encoding=UTF-8
+Type=Application
+Exec=vmware-user-suid-wrapper
+Name=VMware User Agent
+X-KDE-autostart-phase=1
+NoDisplay=true

--- a/app-emulation/open-vm-tools/files/open-vm-tools.initd
+++ b/app-emulation/open-vm-tools/files/open-vm-tools.initd
@@ -1,0 +1,60 @@
+#!/sbin/runscript
+# Copyright 1999-2013 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: /var/cvsroot/gentoo-x86/app-emulation/open-vm-tools/files/open-vm-tools.initd,v 1.4 2013/10/31 20:07:13 floppym Exp $
+
+pidfile="/run/vmtoolsd.pid"
+command="/usr/bin/vmtoolsd"
+command_args="-b ${pidfile}"
+
+vmblockmntpt="/proc/fs/vmblock/mountPoint"
+vmblockfusemntpt="/run/vmblock-fuse"
+
+depend() {
+	before checkfs fsck net X
+}
+
+start_vmblock() {
+	checkpath -d -m 1777 /tmp/VMwareDnD
+	if command -v vmware-vmblock-fuse > /dev/null; then
+		modprobe fuse > /dev/null 2>&1
+		checkpath -d "${vmblockfusemntpt}"
+		ebegin "Mounting vmblock-fuse"
+		vmware-vmblock-fuse \
+			-o subtype=vmware-vmblock,default_permissions,allow_other \
+			"${vmblockfusemntpt}"
+		eend $?
+	else
+		modprobe vmblock > /dev/null 2>&1
+		checkpath -d "${vmblockmntpt}"
+		ebegin "Mounting vmblock"
+		mount -t vmblock vmblock "${vmblockmntpt}"
+		eend $?
+	fi
+}
+
+stop_vmblock() {
+	if [ -d "${vmblockfusemntpt}" ]; then
+		ebegin "Unmounting vmblock-fuse"
+		umount "${vmblockfusemntpt}"
+		eend $?
+	else
+		ebegin "Unmounting vmblock"
+		umount "${vmblockmntpt}"
+		eend $?
+	fi
+}
+
+start_pre() {
+	if [ x"${VM_DRAG_AND_DROP}" = xyes ]; then
+		start_vmblock
+	fi
+	return 0
+}
+
+stop_post() {
+	if [ x"${VM_DRAG_AND_DROP}" = xyes ]; then
+		stop_vmblock
+	fi
+	return 0
+}

--- a/app-emulation/open-vm-tools/files/vmtoolsd.service
+++ b/app-emulation/open-vm-tools/files/vmtoolsd.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Service for virtual machines hosted on VMware
+Documentation=http://open-vm-tools.sourceforge.net/about.php
+ConditionVirtualization=vmware
+
+[Service]
+ExecStart=/usr/bin/vmtoolsd
+TimeoutStopSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/app-emulation/open-vm-tools/metadata.xml
+++ b/app-emulation/open-vm-tools/metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>vmware</herd>
+	<longdescription>
+		The Open Virtual Machine Tools (open-vm-tools) are the open source
+		implementation of VMware Tools. They are a set of guest operating system
+		virtualization components that enhance performance and user experience
+		of virtual machines.
+	</longdescription>
+	<use>
+		<flag name='doc'>Generate API documentation</flag>
+		<flag name='fuse'>Build vmblock-fuse in favor of FUSE based blocking
+		mechanism for DnD</flag>
+		<flag name="pic">Force shared libraries to be built as PIC</flag>
+	</use>
+</pkgmetadata>

--- a/app-emulation/open-vm-tools/open-vm-tools-2013.09.16.1328054_p1-r1.ebuild
+++ b/app-emulation/open-vm-tools/open-vm-tools-2013.09.16.1328054_p1-r1.ebuild
@@ -1,0 +1,126 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: /var/cvsroot/gentoo-x86/app-emulation/open-vm-tools/open-vm-tools-2013.09.16.1328054-r3.ebuild,v 1.1 2014/02/02 15:47:56 floppym Exp $
+
+EAPI=5
+
+inherit eutils multilib pam user versionator flag-o-matic systemd toolchain-funcs
+
+MY_PV="$(replace_version_separator 3 '-' $(get_version_component_range 1-4))"
+MY_P="${PN}-${MY_PV}"
+
+DESCRIPTION="Opensourced tools for VMware guests"
+HOMEPAGE="http://open-vm-tools.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.gz"
+
+LICENSE="LGPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="X doc icu modules pam xinerama"
+
+COMMON_DEPEND="
+	dev-libs/glib:2
+	sys-apps/ethtool
+	sys-process/procps
+	pam? ( virtual/pam )
+	X? (
+		dev-cpp/gtkmm:2.4
+		x11-base/xorg-server
+		x11-drivers/xf86-input-vmmouse
+		x11-drivers/xf86-video-vmware
+		x11-libs/gtk+:2
+		x11-libs/libnotify
+		x11-libs/libX11
+		x11-libs/libXtst
+	)
+	sys-fs/fuse
+	icu? ( dev-libs/icu:= )
+	xinerama? ( x11-libs/libXinerama )
+"
+
+DEPEND="${COMMON_DEPEND}
+	doc? ( app-doc/doxygen )
+	virtual/pkgconfig
+	virtual/linux-sources
+	sys-apps/findutils
+"
+
+# Do not build out-of-tree modules
+# RDEPEND="${COMMON_DEPEND}
+# 	modules? ( app-emulation/open-vm-tools-kmod )
+# "
+
+S="${WORKDIR}/${MY_P}"
+
+pkg_setup() {
+	enewgroup vmware
+}
+
+src_prepare() {
+	# Do not filter out Werror
+	# Upstream Bug  http://sourceforge.net/tracker/?func=detail&aid=2959749&group_id=204462&atid=989708
+	# sed -i -e 's/CFLAGS=.*Werror/#&/g' configure || die "sed comment out Werror failed"
+        sed -i -e 's:\(TEST_PLUGIN_INSTALLDIR=\).*:\1\$libdir/open-vm-tools/plugins/tests:g' configure || die "sed test_plugin_installdir failed"
+        # given that hgfs module won't be built, disable the mounter
+        sed -i -e 's:test "$buildHgfsmounter" = "yes":false:' configure || die "sed hgfsmounter failed"
+}
+
+src_configure() {
+	# http://bugs.gentoo.org/402279
+	if has_version '>=sys-process/procps-3.3.2'; then
+		export CUSTOM_PROCPS_NAME=procps
+		export CUSTOM_PROCPS_LIBS="$($(tc-getPKG_CONFIG) --libs libprocps)"
+	fi
+
+	local myeconfargs=(
+                --with-pic
+                --with-gnu-ld
+		--with-procps
+		--without-dnet
+		--without-kernel-modules
+		$(use_enable doc docs)
+		--docdir=/usr/share/doc/${PF}
+		$(use_with X x)
+		$(use_with X gtk2)
+		$(use_with X gtkmm)
+		$(use_with icu)
+		$(use_with pam)
+		$(use_enable xinerama multimon)
+	)
+
+	econf "${myeconfargs[@]}"
+
+	# Bugs 260878, 326761
+	find ./ -name Makefile | xargs sed -i -e 's/-Werror//g'  || die "sed out Werror failed"
+}
+
+src_install() {
+	default
+
+	rm "${D}"/etc/pam.d/vmtoolsd
+	pamd_mimic_system vmtoolsd auth account
+
+	rm "${D}"/usr/$(get_libdir)/*.la
+	rm "${D}"/usr/$(get_libdir)/open-vm-tools/plugins/common/*.la
+
+	newinitd "${FILESDIR}/open-vm-tools.initd" vmware-tools
+	newconfd "${FILESDIR}/open-vm-tools.confd" vmware-tools
+	systemd_dounit "${FILESDIR}"/vmtoolsd.service
+
+	exeinto /etc/vmware-tools/scripts/vmware/
+	doexe "${FILESDIR}"/network
+
+	if use X;
+	then
+		fperms 4755 "/usr/bin/vmware-user-suid-wrapper"
+
+		dobin "${S}"/scripts/common/vmware-xdg-detect-de
+
+		insinto /etc/xdg/autostart
+		doins "${FILESDIR}/open-vm-tools.desktop"
+
+		elog "To be able to use the drag'n'drop feature of VMware for file"
+		elog "exchange, please add the users to the 'vmware' group."
+	fi
+	elog "Add 'vmware-tools' service to the default runlevel."
+}

--- a/app-emulation/open-vm-tools/open-vm-tools-9999.ebuild
+++ b/app-emulation/open-vm-tools/open-vm-tools-9999.ebuild
@@ -1,0 +1,1 @@
+open-vm-tools-2013.09.16.1328054_p1-r1.ebuild

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -34,6 +34,7 @@ DEPEND="
 	!<dev-db/etcd-0.0.1-r6
 	!coreos-base/oem-service
 	test? ( dev-lang/python:2.7 )
+	app-emulation/open-vm-tools
 	"
 RDEPEND="${DEPEND}
 	sys-block/parted
@@ -58,5 +59,6 @@ src_install() {
 	systemd_enable_service default.target ssh-key-proc-cmdline.service
 	systemd_enable_service sockets.target docker.socket
 	systemd_enable_service default.target issuegen.service
-	systemd_enable_service default.target motdgen.timer
+	systemd_enable_service default.target motdgen.service
+        systemd_enable_service default.target vmtoolsd.service
 }

--- a/profiles/coreos/targets/generic/package.accept_keywords
+++ b/profiles/coreos/targets/generic/package.accept_keywords
@@ -1,1 +1,2 @@
 =app-emulation/lxc-0.8.0-r1	~amd64 ~x86
+=app-emulation/open-vm-tools-2013.09.16.1328054_p1-r1 ~amd64 ~x86


### PR DESCRIPTION
This PR is an attempt at fixing #499. It was a quick hack, and probably could use some cleanup, but I'd like to get feedback regarding the approach. In particular, I'm not very happy that it would end up in every image, even non-vmware ones. But I'm not sure there's an easy way to avoid that, or even if it matters at all.

This adds a customized version of open-vm-tools to the CoreOS build
- dependency to open-vm-tools-kmod is removed to avoid out-of-tree
  kernel modules
- pic is enforced to avoid link error
- hgfsmounter is forcively disabled to avoid binary conflict between
  /usr/bin and /bin (plus it's useless without the corresponding
  kernel module anyway)
- dnet dependency is removed as not part of CoreOS for now

The purpose of this package is primarily to make the vmtoolsd service
available, which allows communication back and forth between the VM
and the host. In particular this allows:
- to control the memory balloon
- to implement correctly power operations
