### PR TITLE
fix(dev-db/etcdctl): Set correct keywords.

### DIFF
--- a/dev-db/etcdctl/etcdctl-9999.ebuild
+++ b/dev-db/etcdctl/etcdctl-9999.ebuild
@@ -21,7 +21,6 @@ SRC_URI=""
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~amd64"
 IUSE=""
 
 DEPEND=">=dev-lang/go-1.2"


### PR DESCRIPTION
Missed this when converting etcdctl to the single ebuild scheme in
02315e21
