### PR TITLE
feat(profiles): Move portage permissions setting out of make.conf

### DIFF
--- a/coreos/config/make.conf.common-target
+++ b/coreos/config/make.conf.common-target
@@ -16,7 +16,6 @@ PORTAGE_TMPDIR=${ROOT}tmp/
 
 PORT_LOGDIR=${ROOT}tmp/portage/logs/
 
-PORTAGE_WORKDIR_MODE="0755"
 PKG_CONFIG_PATH="${ROOT}usr/lib/pkgconfig/:${ROOT}usr/share/pkgconfig/"
 
 PORTDIR="/usr/local/portage/stable"

--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -72,3 +72,6 @@ CCACHE_SIZE="2.5G"
 # Always build binary packages, remove old build logs, avoid running as root.
 FEATURES="buildpkg ccache clean-logs compressdebug parallel-install splitdebug
           userfetch userpriv usersandbox"
+
+# No need to restrict access to build directories in dev environments.
+PORTAGE_WORKDIR_MODE="0755"


### PR DESCRIPTION
Developer friendly permissions are fine as the default in CoreOS.
