### PR TITLE
fix(sys-apps/systemd): Fix build during stage1 bootstrap.

### DIFF
--- a/profiles/coreos/base/package.use.force
+++ b/profiles/coreos/base/package.use.force
@@ -1,0 +1,6 @@
+# Copyright (c) 2014 The CoreOS Authors. All rights reserved.
+# Distributed under the terms of the GNU General Public License v2
+
+# Make sure stage1 bootstrapping does not disable kmod,
+# systemd 213 does not properly build without it.
+~sys-apps/systemd-213 kmod


### PR DESCRIPTION
stage1 builds disable most use flags but systemd 213 fails to build if
kmod is disabled. Work around this by force-enabling the flag.
