### PR TITLE
fix(sys-apps/systemd): Disable elfutils dependency

### DIFF
--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -194,6 +194,8 @@ multilib_src_configure() {
 		# no deps
 		--enable-efi
 		--enable-ima
+		# used for stacktraces in log messages, leave off for now
+		--disable-elfutils
 		# optional components/dependencies
 		$(use_enable acl)
 		$(use_enable audit)


### PR DESCRIPTION
Recently added to systemd, configure is detecting elfutils as present
but compilation fails, perhaps a version mismatch. Need to report this
to Gentoo so they can add a proper use flag and dependency.
