### PR TITLE
profiles: disable calling sync(2) after installing packages

### DIFF
--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -71,7 +71,7 @@ CCACHE_SIZE="2.5G"
 
 # Always build binary packages, remove old build logs, avoid running as root.
 FEATURES="buildpkg ccache clean-logs compressdebug parallel-install splitdebug
-          userfetch userpriv usersandbox"
+          userfetch userpriv usersandbox -merge-sync"
 
 # No need to restrict access to build directories in dev environments.
 PORTAGE_WORKDIR_MODE="0755"


### PR DESCRIPTION
This is just a safety feature for real Gentoo systems on the off chance
that they crash moments after a package is installed. There isn't any
such concern for the CoreOS SDK so just disable it. A normal build_image
is slightly faster with this but I suspect it may help the build host
which is usually running many emerge jobs in parallel.
