### PR TITLE
profiles: add udev to default USE flags

### DIFF
--- a/profiles/features/systemd/make.defaults
+++ b/profiles/features/systemd/make.defaults
@@ -1,2 +1,2 @@
-USE="systemd"
+USE="systemd udev"
 BOOTSTRAP_USE="$BOOTSTRAP_USE udev"


### PR DESCRIPTION
This is normally a default but isn't due to our odd profile setup.
