### PR TITLE
systemd: add compatibility symlink for resolv.conf

### DIFF
--- a/sys-apps/systemd/files/systemd-resolv.conf
+++ b/sys-apps/systemd/files/systemd-resolv.conf
@@ -1,0 +1,2 @@
+d   /run/systemd/network                -   -   -   -   -
+L   /run/systemd/network/resolv.conf    -   -   -   -   ../resolve/resolv.conf

--- a/sys-apps/systemd/systemd-215-r3.ebuild
+++ b/sys-apps/systemd/systemd-215-r3.ebuild
@@ -361,6 +361,7 @@ multilib_src_install_all() {
 	mv "${D}"/usr/lib/sysctl.d/50-coredump.conf{,.disabled} || die
 
 	systemd_dotmpfilesd "${FILESDIR}"/systemd-coreos.conf
+	systemd_dotmpfilesd "${FILESDIR}"/systemd-resolv.conf
 
 	# Don't default to graphical.target
 	rm "${D}"/usr/lib/systemd/system/default.target || die

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -352,6 +352,7 @@ multilib_src_install_all() {
 	mv "${D}"/usr/lib/sysctl.d/50-coredump.conf{,.disabled} || die
 
 	systemd_dotmpfilesd "${FILESDIR}"/systemd-coreos.conf
+	systemd_dotmpfilesd "${FILESDIR}"/systemd-resolv.conf
 
 	# Don't default to graphical.target
 	rm "${D}"/usr/lib/systemd/system/default.target || die


### PR DESCRIPTION
In 215 resolv.conf moved from /run/systemd/network to
/run/systemd/resolv but there isn't anything to fix references to the
old location (namely existing /etc/resolv.conf symlinks after upgrades).
Adding this rule ensures that those links or any other references
continue to work as they did before.

Backport of https://github.com/coreos/coreos-overlay/pull/745
