### PR TITLE
systemd: enable capturing coredumps for inspection via coredumpctl

### DIFF
--- a/sys-apps/systemd/systemd-215-r4.ebuild
+++ b/sys-apps/systemd/systemd-215-r4.ebuild
@@ -357,9 +357,6 @@ multilib_src_install_all() {
 		|| die
 	rm "${D}"/usr/share/man/man1/init.1 || die
 
-	# Disable storing coredumps in journald, bug #433457
-	mv "${D}"/usr/lib/sysctl.d/50-coredump.conf{,.disabled} || die
-
 	systemd_dotmpfilesd "${FILESDIR}"/systemd-coreos.conf
 	systemd_dotmpfilesd "${FILESDIR}"/systemd-resolv.conf
 

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -348,9 +348,6 @@ multilib_src_install_all() {
 		|| die
 	rm "${D}"/usr/share/man/man1/init.1 || die
 
-	# Disable storing coredumps in journald, bug #433457
-	mv "${D}"/usr/lib/sysctl.d/50-coredump.conf{,.disabled} || die
-
 	systemd_dotmpfilesd "${FILESDIR}"/systemd-coreos.conf
 	systemd_dotmpfilesd "${FILESDIR}"/systemd-resolv.conf
 


### PR DESCRIPTION
Gentoo disabled this functionality because coredumpctl didn't exist yet.
It does now and is pretty slick so lets enable this. Dumps are stored in
/var/lib/systemd/coredump by default. Optionally they can be stored in
the journal by modifying /etc/systemd/coredump.conf
