### PR TITLE
eclass: set default portage user and group

### DIFF
--- a/eclass/cros-workon.eclass
+++ b/eclass/cros-workon.eclass
@@ -470,8 +470,8 @@ cros-workon_pkg_setup() {
 	if [[ ${CROS_WORKON_INCREMENTAL_BUILD} == "1" ]]; then
 		local out=$(cros-workon_get_build_dir)
 		addwrite "${out}"
-		mkdir -p -m 755 "${out}"
-		chown ${PORTAGE_USERNAME}:${PORTAGE_GRPNAME} "${out}" "${out%/*}"
+		mkdir -p -m 755 "${out}" || die
+		chown ${PORTAGE_USERNAME:-portage}:${PORTAGE_GRPNAME:-portage} "${out}" "${out%/*}" || die
 	fi
 }
 


### PR DESCRIPTION
The PORTAGE_USERNAME and PORTAGE_GRPNAME variables are not exported by
default. The SDK uses them to get portage to run builds as the
developer's uid/gid instead of portage:portage. When running outside of
the SDK use the default portage user and group.
