### PR TITLE
portage: Add patch to filter EROOT from ebuild environment

### DIFF
--- a/sys-apps/portage/files/portage-2.2.8-filter-eroot.patch
+++ b/sys-apps/portage/files/portage-2.2.8-filter-eroot.patch
@@ -1,0 +1,35 @@
+From 6e0d2f0b0be100c033edf3593fe327bca061f0db Mon Sep 17 00:00:00 2001
+From: Michael Marineau <mike@marineau.org>
+Date: Sun, 20 Jul 2014 20:27:43 -0700
+Subject: [PATCH] environment: Filter EROOT for all EAPIs
+
+This variable is often defined in older EAPIs with "${EROOT:=$ROOT}"
+but it should never be preserved since ROOT may change. Bug #490014
+---
+ bin/phase-functions.sh | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/bin/phase-functions.sh b/bin/phase-functions.sh
+index f39a024..3a62904 100644
+--- a/bin/phase-functions.sh
++++ b/bin/phase-functions.sh
+@@ -101,10 +101,13 @@ __filter_readonly_variables() {
+ 	filtered_vars="$readonly_bash_vars $bash_misc_vars
+ 		$PORTAGE_READONLY_VARS $misc_garbage_vars"
+ 
+-	# Don't filter/interfere with prefix variables unless they are
+-	# supported by the current EAPI.
++	# Always filter EROOT to ensure it is redefined based on ROOT 
++	filtered_vars+=" EROOT"
++
++	# Don't filter/interfere with the other prefix variables unless
++	# they are supported by the current EAPI.
+ 	if ___eapi_has_prefix_variables; then
+-		filtered_vars+=" ED EPREFIX EROOT"
++		filtered_vars+=" ED EPREFIX"
+ 	fi
+ 
+ 	if has --filter-sandbox $* ; then
+-- 
+1.8.5.5
+

--- a/sys-apps/portage/portage-2.2.8-r3.ebuild
+++ b/sys-apps/portage/portage-2.2.8-r3.ebuild
@@ -229,6 +229,7 @@ src_prepare() {
 		epatch "${WORKDIR}/${PN}-${PATCHVER}.patch"
 	fi
 	epatch "${FILESDIR}/${P}-add-disabled.patch"
+	epatch "${FILESDIR}/${P}-filter-eroot.patch"
 	einfo "Setting portage.VERSION to ${PVR} ..."
 	sed -e "s/^VERSION=.*/VERSION=\"${PVR}\"/" -i pym/portage/__init__.py || \
 		die "Failed to patch portage.VERSION"


### PR DESCRIPTION
EROOT must always be derived from ROOT, preserving it causes binary
packages to break in mysterious and often silent ways.

Upstream: https://bugs.gentoo.org/show_bug.cgi?id=490014
Related: https://github.com/coreos/portage-stable/pull/125

This change doesn't impact images just yet since this portage version is still marked unstable. The old binutils will need to be flushed from our system before we can safely use portage with this patch.
