### PR TITLE
mit-krb5: work around broken autoconf tests

### DIFF
--- a/coreos/config/env/app-crypt/mit-krb5
+++ b/coreos/config/env/app-crypt/mit-krb5
@@ -1,0 +1,4 @@
+# work around configure test that cannot be cross compiled :(
+export krb5_cv_attr_constructor_destructor=yes,yes
+export ac_cv_func_regcomp=yes
+export ac_cv_printf_positional=yes


### PR DESCRIPTION
The configure script attempts several tests that cannot be used when
cross compiling. Export the various autoconf vars instead.
