### PR TITLE
profiles: disable kerberos in SDK ssh client

### DIFF
--- a/profiles/coreos/targets/sdk/package.use
+++ b/profiles/coreos/targets/sdk/package.use
@@ -5,7 +5,6 @@ app-arch/pigz static
 dev-libs/glib static-libs
 
 coreos-base/update_engine delta_generator
-net-misc/openssh kerberos
 sys-apps/flashrom dediprog ft2232_spi serprog
 
 dev-vcs/git pcre


### PR DESCRIPTION
Left over from the SDK's days at Google. Noticed this because the
SDK build failed after bumping the krb related packages yesterday.
