### PR TITLE
systemd: fix ordering between tmpfiles and ldconfig

### DIFF
--- a/sys-apps/systemd/files/0002-units-run-ldconfig-after-tmpfiles-setup-to-ensure-ld.patch
+++ b/sys-apps/systemd/files/0002-units-run-ldconfig-after-tmpfiles-setup-to-ensure-ld.patch
@@ -1,0 +1,27 @@
+From a5ad570fc0577080f994ac7f864470aa9fbd95d8 Mon Sep 17 00:00:00 2001
+From: Michael Marineau <mike@marineau.org>
+Date: Sun, 3 Aug 2014 18:16:07 -0700
+Subject: [PATCH] units: run ldconfig after tmpfiles-setup to ensure ld.so.conf
+ exists
+
+We lost this ordering when we switched to this unit instead of our own.
+---
+ units/ldconfig.service | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/units/ldconfig.service b/units/ldconfig.service
+index 43c145b..c8d9b6b 100644
+--- a/units/ldconfig.service
++++ b/units/ldconfig.service
+@@ -10,7 +10,7 @@ Description=Rebuild Dynamic Linker Cache
+ Documentation=man:ldconfig(8)
+ DefaultDependencies=no
+ Conflicts=shutdown.target
+-After=systemd-readahead-collect.service systemd-readahead-replay.service systemd-remount-fs.service
++After=systemd-readahead-collect.service systemd-readahead-replay.service systemd-remount-fs.service systemd-tmpfiles-setup.service
+ Before=sysinit.target shutdown.target systemd-update-done.service
+ ConditionNeedsUpdate=/etc
+ 
+-- 
+1.8.5.5
+

--- a/sys-apps/systemd/systemd-215-r12.ebuild
+++ b/sys-apps/systemd/systemd-215-r12.ebuild
@@ -117,8 +117,9 @@ fi
 	# backports from master
 	epatch "${FILESDIR}"/215-*.patch
 
-	# remove -Wl,-fuse-ld=gold
+	# patches not upstream
 	epatch "${FILESDIR}"/0001-hack-testing-Wl-fuse-ld-gold-does-not-work-correctly.patch
+	epatch "${FILESDIR}"/0002-units-run-ldconfig-after-tmpfiles-setup-to-ensure-ld.patch
 
 	# Bug 463376
 	sed -i -e 's/GROUP="dialout"/GROUP="uucp"/' rules/*.rules || die

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -110,8 +110,9 @@ if [[ ${PV} == *9999 ]]; then
 		echo 'EXTRA_DIST =' > docs/gtk-doc.make
 	fi
 fi
-	# remove -Wl,-fuse-ld=gold
+	# patches not upstream
 	epatch "${FILESDIR}"/0001-hack-testing-Wl-fuse-ld-gold-does-not-work-correctly.patch
+	epatch "${FILESDIR}"/0002-units-run-ldconfig-after-tmpfiles-setup-to-ensure-ld.patch
 
 	# Bug 463376
 	sed -i -e 's/GROUP="dialout"/GROUP="uucp"/' rules/*.rules || die


### PR DESCRIPTION
C++ binaries are broken on PXE images in the current alpha. :(
