### PR TITLE
systemd: fix udev crash when network devices lack a hwaddr

### DIFF
--- a/sys-apps/systemd/files/215-0001-machine-don-t-return-uninitialized-variable.patch
+++ b/sys-apps/systemd/files/215-0001-machine-don-t-return-uninitialized-variable.patch
@@ -1,7 +1,7 @@
 From d26956e27de9ec6d7bfd22da985136ae22930eaf Mon Sep 17 00:00:00 2001
 From: Tom Gundersen <teg@jklm.no>
 Date: Sun, 6 Jul 2014 14:12:28 +0200
-Subject: [PATCH 01/32] machine: don't return uninitialized variable
+Subject: [PATCH 01/37] machine: don't return uninitialized variable
 
 Repotred by Ronny Chevalier
 ---

--- a/sys-apps/systemd/files/215-0002-vconsole-setup-run-setfont-before-loadkeys.patch
+++ b/sys-apps/systemd/files/215-0002-vconsole-setup-run-setfont-before-loadkeys.patch
@@ -1,7 +1,7 @@
 From 79c9e82026d0c2e9466a5b2bc81ee7a3d16b1ade Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@in.waw.pl>
 Date: Tue, 1 Jul 2014 22:20:11 -0400
-Subject: [PATCH 02/32] vconsole-setup: run setfont before loadkeys
+Subject: [PATCH 02/37] vconsole-setup: run setfont before loadkeys
 
 https://bugs.freedesktop.org/show_bug.cgi?id=80685
 ---

--- a/sys-apps/systemd/files/215-0003-vconsole-setup-fix-inverted-error-messages.patch
+++ b/sys-apps/systemd/files/215-0003-vconsole-setup-fix-inverted-error-messages.patch
@@ -1,7 +1,7 @@
 From b44c15f77e59d40d5bdf5608bf8d76cc2375ac6e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@in.waw.pl>
 Date: Mon, 7 Jul 2014 08:55:30 -0400
-Subject: [PATCH 03/32] vconsole-setup: fix inverted error messages
+Subject: [PATCH 03/37] vconsole-setup: fix inverted error messages
 
 Introduced in abee28c56d.
 

--- a/sys-apps/systemd/files/215-0004-udev-link_config-ignore-errors-due-to-missing-MAC-ad.patch
+++ b/sys-apps/systemd/files/215-0004-udev-link_config-ignore-errors-due-to-missing-MAC-ad.patch
@@ -1,7 +1,7 @@
 From 36749d890949896f3105fc852cfb5b8c2f22af3e Mon Sep 17 00:00:00 2001
 From: Tom Gundersen <teg@jklm.no>
 Date: Mon, 7 Jul 2014 14:50:16 +0200
-Subject: [PATCH 04/32] udev: link_config - ignore errors due to missing MAC
+Subject: [PATCH 04/37] udev: link_config - ignore errors due to missing MAC
  address
 
 Otherwis, we get misleading error messages on links with MACs.

--- a/sys-apps/systemd/files/215-0005-util-consider-0x7F-a-control-chracter-which-it-is-DE.patch
+++ b/sys-apps/systemd/files/215-0005-util-consider-0x7F-a-control-chracter-which-it-is-DE.patch
@@ -1,7 +1,7 @@
 From 1335bbd1c9dd114d6491f08bc3b2c5eaf3768a04 Mon Sep 17 00:00:00 2001
 From: Lennart Poettering <lennart@poettering.net>
 Date: Mon, 7 Jul 2014 11:47:10 +0200
-Subject: [PATCH 05/32] util: consider 0x7F a control chracter (which it is:
+Subject: [PATCH 05/37] util: consider 0x7F a control chracter (which it is:
  DEL)
 
 Let's better be safe than sorry.

--- a/sys-apps/systemd/files/215-0006-man-add-missing-archs-to-ConditionArchitecture-descr.patch
+++ b/sys-apps/systemd/files/215-0006-man-add-missing-archs-to-ConditionArchitecture-descr.patch
@@ -1,7 +1,7 @@
 From efbcb2ef7b6337530ece0a251b80b35c109fcdf7 Mon Sep 17 00:00:00 2001
 From: Lennart Poettering <lennart@poettering.net>
 Date: Mon, 7 Jul 2014 14:58:13 +0200
-Subject: [PATCH 06/32] man: add missing archs to ConditionArchitecture=
+Subject: [PATCH 06/37] man: add missing archs to ConditionArchitecture=
  description
 
 ---

--- a/sys-apps/systemd/files/215-0007-man-chroot-jails-are-no-longer-detected-by-Condition.patch
+++ b/sys-apps/systemd/files/215-0007-man-chroot-jails-are-no-longer-detected-by-Condition.patch
@@ -1,7 +1,7 @@
 From cb59448753d949cd31c5a84bccc37f10597e23d7 Mon Sep 17 00:00:00 2001
 From: Lennart Poettering <lennart@poettering.net>
 Date: Mon, 7 Jul 2014 14:58:36 +0200
-Subject: [PATCH 07/32] man: chroot jails are no longer detected by
+Subject: [PATCH 07/37] man: chroot jails are no longer detected by
  ConditionVirtualization=
 
 ---

--- a/sys-apps/systemd/files/215-0008-base-filesystem.c-terminate-string-array-elements-wi.patch
+++ b/sys-apps/systemd/files/215-0008-base-filesystem.c-terminate-string-array-elements-wi.patch
@@ -1,7 +1,7 @@
 From 5055a12659b731d78cc30553576193905b6530ae Mon Sep 17 00:00:00 2001
 From: Harald Hoyer <harald@redhat.com>
 Date: Mon, 7 Jul 2014 17:45:53 +0200
-Subject: [PATCH 08/32] base-filesystem.c: terminate string array elements with
+Subject: [PATCH 08/37] base-filesystem.c: terminate string array elements with
  \0
 
 NULSTR_FOREACH() looks for a terminating zero and the element also needs

--- a/sys-apps/systemd/files/215-0009-man-drop-references-to-the-priviliged-command-line-o.patch
+++ b/sys-apps/systemd/files/215-0009-man-drop-references-to-the-priviliged-command-line-o.patch
@@ -1,7 +1,7 @@
 From 1a45876927c5a2fb7a48d4ecd00359b37b8e1c4f Mon Sep 17 00:00:00 2001
 From: Lennart Poettering <lennart@poettering.net>
 Date: Mon, 7 Jul 2014 18:45:07 +0200
-Subject: [PATCH 09/32] man: drop references to the --priviliged command line
+Subject: [PATCH 09/37] man: drop references to the --priviliged command line
  option which has been removed a while back
 
 ---

--- a/sys-apps/systemd/files/215-0010-fstab-generator-add-comma-when-removed-option-is-in-.patch
+++ b/sys-apps/systemd/files/215-0010-fstab-generator-add-comma-when-removed-option-is-in-.patch
@@ -1,7 +1,7 @@
 From f71f5fa7f6796cb809a2b827a5348cc494c128e1 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@in.waw.pl>
 Date: Mon, 7 Jul 2014 16:10:38 -0400
-Subject: [PATCH 10/32] fstab-generator: add comma when removed option is in
+Subject: [PATCH 10/37] fstab-generator: add comma when removed option is in
  the middle
 
 xxx,x-systemd.default-timeout=y,zzz was filtered to xxxzzz,

--- a/sys-apps/systemd/files/215-0011-dropin-add-format-attribute-and-fix-a-wrong-caller.patch
+++ b/sys-apps/systemd/files/215-0011-dropin-add-format-attribute-and-fix-a-wrong-caller.patch
@@ -1,7 +1,7 @@
 From 05e483d224be6a7c057a7b6eb30d830fea18eda8 Mon Sep 17 00:00:00 2001
 From: Thomas Hindoe Paaboel Andersen <phomes@gmail.com>
 Date: Mon, 7 Jul 2014 21:40:00 +0200
-Subject: [PATCH 11/32] dropin: add format attribute and fix a wrong caller
+Subject: [PATCH 11/37] dropin: add format attribute and fix a wrong caller
 
 ---
  src/shared/dropin.h    | 4 +++-

--- a/sys-apps/systemd/files/215-0012-shared-fix-format-string-for-usec_t-type.patch
+++ b/sys-apps/systemd/files/215-0012-shared-fix-format-string-for-usec_t-type.patch
@@ -1,7 +1,7 @@
 From 8070ab78b7bba4a20bba278086580d6582c96e80 Mon Sep 17 00:00:00 2001
 From: Lennart Poettering <lennart@poettering.net>
 Date: Mon, 7 Jul 2014 22:49:59 +0200
-Subject: [PATCH 12/32] shared: fix format string for usec_t type
+Subject: [PATCH 12/37] shared: fix format string for usec_t type
 
 ---
  src/shared/generator.c | 2 +-

--- a/sys-apps/systemd/files/215-0013-logind-allow-switching-to-unused-VTs-via-SwitchTo.patch
+++ b/sys-apps/systemd/files/215-0013-logind-allow-switching-to-unused-VTs-via-SwitchTo.patch
@@ -1,7 +1,7 @@
 From 82155b957fac44db3858e1b008cf31e5004d40cd Mon Sep 17 00:00:00 2001
 From: David Herrmann <dh.herrmann@gmail.com>
 Date: Tue, 8 Jul 2014 12:56:55 +0200
-Subject: [PATCH 13/32] logind: allow switching to unused VTs via SwitchTo()
+Subject: [PATCH 13/37] logind: allow switching to unused VTs via SwitchTo()
 
 If compositors use the new SwitchTo() logic to map F1-F12, we should allow
 them to switch to unregistered VTs, too. Otherwise, the auto-spawn logic

--- a/sys-apps/systemd/files/215-0014-systemctl-fix-visual-alignment-for-lines-prefixed-wi.patch
+++ b/sys-apps/systemd/files/215-0014-systemctl-fix-visual-alignment-for-lines-prefixed-wi.patch
@@ -1,7 +1,7 @@
 From d91cba9f5ed3aee340115bd4b4097bf3bf396365 Mon Sep 17 00:00:00 2001
 From: Michal Schmidt <mschmidt@redhat.com>
 Date: Tue, 8 Jul 2014 15:17:36 +0200
-Subject: [PATCH 14/32] systemctl: fix visual alignment for lines prefixed with
+Subject: [PATCH 14/37] systemctl: fix visual alignment for lines prefixed with
  color dots
 
 ---

--- a/sys-apps/systemd/files/215-0015-accelerometer-Don-t-wait-for-new-data-from-the-senso.patch
+++ b/sys-apps/systemd/files/215-0015-accelerometer-Don-t-wait-for-new-data-from-the-senso.patch
@@ -1,7 +1,7 @@
 From 18dd397f6383eb21ba383840dd9b10feaca4a663 Mon Sep 17 00:00:00 2001
 From: Bastien Nocera <hadess@hadess.net>
 Date: Tue, 8 Jul 2014 18:29:06 +0200
-Subject: [PATCH 15/32] accelerometer: Don't wait for new data from the sensor
+Subject: [PATCH 15/37] accelerometer: Don't wait for new data from the sensor
 
 Instead of waiting for new data from the sensor, which might be
 a long time coming, depending on the sensor device, ask the kernel

--- a/sys-apps/systemd/files/215-0016-sysusers-don-t-allow-user-names-longer-than-UT_NAMES.patch
+++ b/sys-apps/systemd/files/215-0016-sysusers-don-t-allow-user-names-longer-than-UT_NAMES.patch
@@ -1,7 +1,7 @@
 From c4067527b6c8875b1cb767cf4efd14998cf17c34 Mon Sep 17 00:00:00 2001
 From: Lennart Poettering <lennart@poettering.net>
 Date: Wed, 9 Jul 2014 19:20:58 +0200
-Subject: [PATCH 16/32] sysusers: don't allow user names longer than
+Subject: [PATCH 16/37] sysusers: don't allow user names longer than
  UT_NAMESIZE
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/sys-apps/systemd/files/215-0017-Revert-build-sys-include-PolicyKit-files-as-part-of-.patch
+++ b/sys-apps/systemd/files/215-0017-Revert-build-sys-include-PolicyKit-files-as-part-of-.patch
@@ -1,7 +1,7 @@
 From b407f12e7656916b25b3b3c006290187e1064793 Mon Sep 17 00:00:00 2001
 From: Mike Gilbert <floppym@gentoo.org>
 Date: Fri, 4 Jul 2014 14:43:14 -0400
-Subject: [PATCH 17/32] Revert "build-sys: include PolicyKit files as part of
+Subject: [PATCH 17/37] Revert "build-sys: include PolicyKit files as part of
  distribution"
 
 This reverts commit 0c26bfc3d21fdb3963f1248c237e2f1a33b5566d.

--- a/sys-apps/systemd/files/215-0018-build-sys-Do-not-distribute-generated-emergency.serv.patch
+++ b/sys-apps/systemd/files/215-0018-build-sys-Do-not-distribute-generated-emergency.serv.patch
@@ -1,7 +1,7 @@
 From 669455ef0d5a3cf56c03c9fc668daa0750629cf5 Mon Sep 17 00:00:00 2001
 From: Jon Severinsson <jon@severinsson.net>
 Date: Fri, 11 Jul 2014 14:37:36 +0200
-Subject: [PATCH 18/32] build-sys: Do not distribute generated
+Subject: [PATCH 18/37] build-sys: Do not distribute generated
  emergency.service
 
 It is already in nodist_systemunit_DATA and if it is

--- a/sys-apps/systemd/files/215-0019-man-sysusers.d-correct-default-user-shell.patch
+++ b/sys-apps/systemd/files/215-0019-man-sysusers.d-correct-default-user-shell.patch
@@ -1,7 +1,7 @@
 From c49b22614e4a6f843f8c2395d22bedf335f79fde Mon Sep 17 00:00:00 2001
 From: Sjoerd Simons <sjoerd@luon.net>
 Date: Sun, 13 Jul 2014 16:56:16 +0200
-Subject: [PATCH 19/32] man: sysusers.d correct default user shell
+Subject: [PATCH 19/37] man: sysusers.d correct default user shell
 
 For the non-root user sysusers uses nologin as the default shell, not
 login. Correct the documentation to match the code.

--- a/sys-apps/systemd/files/215-0020-rules-consistently-use-instead-of.patch
+++ b/sys-apps/systemd/files/215-0020-rules-consistently-use-instead-of.patch
@@ -1,7 +1,7 @@
 From 584152929252c948e9826bc3c735165ea1328737 Mon Sep 17 00:00:00 2001
 From: Kay Sievers <kay@vrfy.org>
 Date: Tue, 15 Jul 2014 02:04:47 +0200
-Subject: [PATCH 20/32] rules: consistently use "?*" instead of "*?"
+Subject: [PATCH 20/37] rules: consistently use "?*" instead of "*?"
 
 ---
  rules/99-systemd.rules.in  |  2 +-

--- a/sys-apps/systemd/files/215-0021-timesyncd-suppress-resync-at-system-time-change-when.patch
+++ b/sys-apps/systemd/files/215-0021-timesyncd-suppress-resync-at-system-time-change-when.patch
@@ -1,7 +1,7 @@
 From 19c0af955631f8a32b3c95232cfcb4682dc362d6 Mon Sep 17 00:00:00 2001
 From: Kay Sievers <kay@vrfy.org>
 Date: Tue, 15 Jul 2014 02:24:35 +0200
-Subject: [PATCH 21/32] timesyncd: suppress resync at system time change when
+Subject: [PATCH 21/37] timesyncd: suppress resync at system time change when
  not connected
 
 Jul 04 17:46:03 orchid systemd[1]: Starting Network Time Synchronization...

--- a/sys-apps/systemd/files/215-0022-timesyncd-only-listen-to-clock-changes-when-connecte.patch
+++ b/sys-apps/systemd/files/215-0022-timesyncd-only-listen-to-clock-changes-when-connecte.patch
@@ -1,7 +1,7 @@
 From 446e61ba07ec949544594729cdd2dff79c8e4cdc Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@in.waw.pl>
 Date: Tue, 15 Jul 2014 09:52:17 -0400
-Subject: [PATCH 22/32] timesyncd: only listen to clock changes when connected
+Subject: [PATCH 22/37] timesyncd: only listen to clock changes when connected
 
 This reverts previous commit and applies a different fix.
 

--- a/sys-apps/systemd/files/215-0023-core-fix-oneshot-service-resource-control.patch
+++ b/sys-apps/systemd/files/215-0023-core-fix-oneshot-service-resource-control.patch
@@ -1,7 +1,7 @@
 From bdabb3772ddd38ef7a62342efaa5b23d77765e5b Mon Sep 17 00:00:00 2001
 From: Umut Tezduyar Lindskog <umut.tezduyar@axis.com>
 Date: Tue, 15 Jul 2014 08:36:29 +0200
-Subject: [PATCH 23/32] core: fix oneshot service resource control
+Subject: [PATCH 23/37] core: fix oneshot service resource control
 
 Oneshot services's cgroup is removed when the service
 exits. An assert is hit otherwise.

--- a/sys-apps/systemd/files/215-0024-journal-allow-files-with-no-data-whatsoever.patch
+++ b/sys-apps/systemd/files/215-0024-journal-allow-files-with-no-data-whatsoever.patch
@@ -1,7 +1,7 @@
 From 168b42d2860dcaaa4f4970f96467da1007cd78f5 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@in.waw.pl>
 Date: Sun, 30 Mar 2014 14:20:34 -0400
-Subject: [PATCH 24/32] journal: allow files with no data whatsoever
+Subject: [PATCH 24/37] journal: allow files with no data whatsoever
 
 If a file was opened for writing, and then closed immediately without
 actually writing any entries, on subsequent opening, it would be

--- a/sys-apps/systemd/files/215-0025-units-serial-getty-.service-use-the-default-RestartS.patch
+++ b/sys-apps/systemd/files/215-0025-units-serial-getty-.service-use-the-default-RestartS.patch
@@ -1,7 +1,7 @@
 From 0a9a32ccbb38db14ff5dc8455af8cdac9610fbce Mon Sep 17 00:00:00 2001
 From: Michael Olbrich <m.olbrich@pengutronix.de>
 Date: Tue, 15 Jul 2014 18:28:10 +0200
-Subject: [PATCH 25/32] units/serial-getty@.service: use the default RestartSec
+Subject: [PATCH 25/37] units/serial-getty@.service: use the default RestartSec
 
 For pluggable ttys such as USB serial devices, the getty is restarted
 and exits in a loop until the remove event reaches systemd. Under

--- a/sys-apps/systemd/files/215-0026-networkd-properly-track-addresses-when-first-added.patch
+++ b/sys-apps/systemd/files/215-0026-networkd-properly-track-addresses-when-first-added.patch
@@ -1,7 +1,7 @@
 From c831530cf5cf6795e6c465c51689481a308a20a0 Mon Sep 17 00:00:00 2001
 From: Tom Gundersen <teg@jklm.no>
 Date: Thu, 3 Jul 2014 22:47:51 +0200
-Subject: [PATCH 26/32] networkd: properly track addresses when first added
+Subject: [PATCH 26/37] networkd: properly track addresses when first added
 
 When doing a NEWADDR, the reply we get back is the NEWADDR itself, rather
 than just an empty ack (unlike how NEWLINK works). For this reason, the

--- a/sys-apps/systemd/files/215-0027-networkd-don-t-clear-dhcpv6-lease-timers-if-there-s-.patch
+++ b/sys-apps/systemd/files/215-0027-networkd-don-t-clear-dhcpv6-lease-timers-if-there-s-.patch
@@ -1,7 +1,7 @@
 From f491638dd12ad53539d62f5a1088eb26e233badf Mon Sep 17 00:00:00 2001
 From: Steven Noonan <steven@uplinklabs.net>
 Date: Thu, 3 Jul 2014 19:43:56 -0700
-Subject: [PATCH 27/32] networkd: don't clear dhcpv6 lease timers if there's no
+Subject: [PATCH 27/37] networkd: don't clear dhcpv6 lease timers if there's no
  previous lease
 
 If client->lease is NULL, dhcp6_lease_clear_timers will cause a segmentation

--- a/sys-apps/systemd/files/215-0028-networkd-accept-section-DHCP-in-systemd.network-file.patch
+++ b/sys-apps/systemd/files/215-0028-networkd-accept-section-DHCP-in-systemd.network-file.patch
@@ -1,7 +1,7 @@
 From 49047278910689c619b768130cce40c377fa5560 Mon Sep 17 00:00:00 2001
 From: Steven Noonan <steven@uplinklabs.net>
 Date: Thu, 3 Jul 2014 19:42:19 -0700
-Subject: [PATCH 28/32] networkd: accept section DHCP in systemd.network files
+Subject: [PATCH 28/37] networkd: accept section DHCP in systemd.network files
 
 ---
  src/network/networkd-network.c | 2 +-

--- a/sys-apps/systemd/files/215-0029-dhcp-network-add-check-for-DHCP.chaddr.patch
+++ b/sys-apps/systemd/files/215-0029-dhcp-network-add-check-for-DHCP.chaddr.patch
@@ -1,7 +1,7 @@
 From f0b0beb95c95235ffc88d7230334f93e37982b04 Mon Sep 17 00:00:00 2001
 From: Michal Sekletar <msekleta@redhat.com>
 Date: Thu, 19 Jun 2014 15:14:14 +0200
-Subject: [PATCH 29/32] dhcp-network: add check for DHCP.chaddr
+Subject: [PATCH 29/37] dhcp-network: add check for DHCP.chaddr
 
 Check that received DHCP packets actually include our MAC address in
 chaddr field. BPF interpreter has 32 bit wide registers but MAC address

--- a/sys-apps/systemd/files/215-0030-networkd-netdev-add-missing-refs.patch
+++ b/sys-apps/systemd/files/215-0030-networkd-netdev-add-missing-refs.patch
@@ -1,7 +1,7 @@
 From 5c7eaa88675fc6e400420bbeb4890ef13b18b85b Mon Sep 17 00:00:00 2001
 From: Tom Gundersen <teg@jklm.no>
 Date: Mon, 7 Jul 2014 14:18:26 +0200
-Subject: [PATCH 30/32] networkd: netdev - add missing refs
+Subject: [PATCH 30/37] networkd: netdev - add missing refs
 
 Without this, the underlying device would get freed (and hence
 fail).

--- a/sys-apps/systemd/files/215-0031-networkd-link-fix-memory-leak.patch
+++ b/sys-apps/systemd/files/215-0031-networkd-link-fix-memory-leak.patch
@@ -1,7 +1,7 @@
 From 25bb651691c89caa40d57ca6cb347fbbf20633c5 Mon Sep 17 00:00:00 2001
 From: Tom Gundersen <teg@jklm.no>
 Date: Sun, 13 Jul 2014 01:11:52 +0200
-Subject: [PATCH 31/32] networkd: link - fix memory leak
+Subject: [PATCH 31/37] networkd: link - fix memory leak
 
 Make link_initialized() idempotent to avoid taking refs on several udev_device
 objects.

--- a/sys-apps/systemd/files/215-0032-sd-dhcp-client-make-request-broadcasts-opt-in.patch
+++ b/sys-apps/systemd/files/215-0032-sd-dhcp-client-make-request-broadcasts-opt-in.patch
@@ -1,7 +1,7 @@
 From 64e271490cf958e5554ddb8daa662c84c2003452 Mon Sep 17 00:00:00 2001
 From: Tom Gundersen <teg@jklm.no>
 Date: Tue, 15 Jul 2014 18:55:31 +0200
-Subject: [PATCH 32/32] sd-dhcp-client: make request broadcasts opt-in
+Subject: [PATCH 32/37] sd-dhcp-client: make request broadcasts opt-in
 
 It appears there is no good way to decide whether or not broadcasts should be enabled,
 there is hardware that must have broadcast, and there are networks that only allow

--- a/sys-apps/systemd/files/215-0033-networkd-fix-reporting-errors-from-hostnamed.patch
+++ b/sys-apps/systemd/files/215-0033-networkd-fix-reporting-errors-from-hostnamed.patch
@@ -1,7 +1,7 @@
 From cd210f1210700a9917412cb6d312eb029236f1ae Mon Sep 17 00:00:00 2001
 From: Michael Marineau <michael.marineau@coreos.com>
 Date: Mon, 21 Jul 2014 16:11:00 -0700
-Subject: [PATCH 33/33] networkd: fix reporting errors from hostnamed
+Subject: [PATCH 33/37] networkd: fix reporting errors from hostnamed
 
 The return value may be -EINVAL or a positive errno from the dbus
 message. Check both ranges, otherwise most errors are silently ignored.

--- a/sys-apps/systemd/files/215-0034-resolved-re-add-support-for-getting-local-domain-fro.patch
+++ b/sys-apps/systemd/files/215-0034-resolved-re-add-support-for-getting-local-domain-fro.patch
@@ -1,7 +1,7 @@
 From 9a1aced57aaa6767298667c72308157d849282dc Mon Sep 17 00:00:00 2001
 From: Michael Marineau <michael.marineau@coreos.com>
 Date: Tue, 22 Jul 2014 17:56:40 -0700
-Subject: [PATCH 34/34] resolved: re-add support for getting local domain from
+Subject: [PATCH 34/37] resolved: re-add support for getting local domain from
  DHCP
 
 When the code for generating resolv.conf was moved from networkd to

--- a/sys-apps/systemd/files/215-0035-hack-testing-Wl-fuse-ld-gold-does-not-work-correctly.patch
+++ b/sys-apps/systemd/files/215-0035-hack-testing-Wl-fuse-ld-gold-does-not-work-correctly.patch
@@ -1,0 +1,47 @@
+From 00197239142c519270e44f94b1126a45e7f65511 Mon Sep 17 00:00:00 2001
+From: Michael Marineau <michael.marineau@coreos.com>
+Date: Sat, 2 Aug 2014 17:45:00 -0700
+Subject: [PATCH 35/37] hack: testing -Wl,-fuse-ld=gold does not work correctly
+ on hardened
+
+Not sure why this test falsely passes with the hardened compiler when it
+normally will report the following error:
+
+    ld: -f may not be used without -shared
+
+But apparently the default options hardened uses makes interpreting the
+option as -f valid usage. For reference the option is:
+
+    -f name
+    --auxiliary=name
+        When creating an ELF shared object, set the internal DT_AUXILIARY
+        field to the specified name.  This tells the dynamic linker that
+        the symbol table of the shared object should be used as an
+        auxiliary filter on the symbol table of the shared object name.
+
+This in turn causes a stray library to show up in ldd output:
+
+    use-ld=gold => not found
+
+Which seems mostly harmless but does cause some confusion.
+---
+ configure.ac | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index ae88382..85966b9 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -216,8 +216,7 @@ CC_CHECK_FLAGS_APPEND([with_ldflags], [LDFLAGS], [\
+         -Wl,--gc-sections \
+         -Wl,-z,relro \
+         -Wl,-z,now \
+-        -pie \
+-        -Wl,-fuse-ld=gold])
++        -pie])
+ AC_SUBST([OUR_LDFLAGS], "$with_ldflags $sanitizer_ldflags")
+ 
+ AC_CHECK_SIZEOF(pid_t)
+-- 
+1.8.5.5
+

--- a/sys-apps/systemd/files/215-0036-units-run-ldconfig-after-tmpfiles-setup-to-ensure-ld.patch
+++ b/sys-apps/systemd/files/215-0036-units-run-ldconfig-after-tmpfiles-setup-to-ensure-ld.patch
@@ -1,0 +1,27 @@
+From a5ad570fc0577080f994ac7f864470aa9fbd95d8 Mon Sep 17 00:00:00 2001
+From: Michael Marineau <mike@marineau.org>
+Date: Sun, 3 Aug 2014 18:16:07 -0700
+Subject: [PATCH 36/37] units: run ldconfig after tmpfiles-setup to ensure
+ ld.so.conf exists
+
+We lost this ordering when we switched to this unit instead of our own.
+---
+ units/ldconfig.service | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/units/ldconfig.service b/units/ldconfig.service
+index 43c145b..c8d9b6b 100644
+--- a/units/ldconfig.service
++++ b/units/ldconfig.service
+@@ -10,7 +10,7 @@ Description=Rebuild Dynamic Linker Cache
+ Documentation=man:ldconfig(8)
+ DefaultDependencies=no
+ Conflicts=shutdown.target
+-After=systemd-readahead-collect.service systemd-readahead-replay.service systemd-remount-fs.service
++After=systemd-readahead-collect.service systemd-readahead-replay.service systemd-remount-fs.service systemd-tmpfiles-setup.service
+ Before=sysinit.target shutdown.target systemd-update-done.service
+ ConditionNeedsUpdate=/etc
+ 
+-- 
+1.8.5.5
+

--- a/sys-apps/systemd/files/215-0037-udev-link-config-fix-crash-due-to-missing-hwaddr.patch
+++ b/sys-apps/systemd/files/215-0037-udev-link-config-fix-crash-due-to-missing-hwaddr.patch
@@ -1,0 +1,31 @@
+From b53858105bc92861a2025694437e65f81ff19ecf Mon Sep 17 00:00:00 2001
+From: Tom Gundersen <teg@jklm.no>
+Date: Thu, 14 Aug 2014 01:35:16 +0200
+Subject: [PATCH 37/37] udev: link-config - fix crash due to missing hwaddr
+
+Reported by: master.nosferatu@gmail.com
+---
+ src/udev/net/link-config.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/udev/net/link-config.c b/src/udev/net/link-config.c
+index 5a45c53..3cc0471 100644
+--- a/src/udev/net/link-config.c
++++ b/src/udev/net/link-config.c
+@@ -247,11 +247,12 @@ int link_config_get(link_config_ctx *ctx, struct udev_device *device, link_confi
+         link_config *link;
+ 
+         LIST_FOREACH(links, link, ctx->links) {
++                const char* attr_value = udev_device_get_sysattr_value(device, "address");
+ 
+                 if (net_match_config(link->match_mac, link->match_path, link->match_driver,
+                                      link->match_type, NULL, link->match_host,
+                                      link->match_virt, link->match_kernel, link->match_arch,
+-                                     ether_aton(udev_device_get_sysattr_value(device, "address")),
++                                     attr_value ? ether_aton(attr_value) : NULL,
+                                      udev_device_get_property_value(device, "ID_PATH"),
+                                      udev_device_get_driver(udev_device_get_parent(device)),
+                                      udev_device_get_property_value(device, "ID_NET_DRIVER"),
+-- 
+1.8.5.5
+

--- a/sys-apps/systemd/systemd-215-r13.ebuild
+++ b/sys-apps/systemd/systemd-215-r13.ebuild
@@ -117,10 +117,6 @@ fi
 	# backports from master
 	epatch "${FILESDIR}"/215-*.patch
 
-	# patches not upstream
-	epatch "${FILESDIR}"/0001-hack-testing-Wl-fuse-ld-gold-does-not-work-correctly.patch
-	epatch "${FILESDIR}"/0002-units-run-ldconfig-after-tmpfiles-setup-to-ensure-ld.patch
-
 	# Bug 463376
 	sed -i -e 's/GROUP="dialout"/GROUP="uucp"/' rules/*.rules || die
 


### PR DESCRIPTION
This refreshes the full set of 215 patches from my v215-coreos branch.
