### PR TITLE
profiles: do not enable the python use flag globally in the SDK

### DIFF
--- a/profiles/coreos/targets/sdk/make.defaults
+++ b/profiles/coreos/targets/sdk/make.defaults
@@ -1,1 +1,1 @@
-USE="-pam python"
+USE="-pam"


### PR DESCRIPTION
This is not actually needed for most things, just adds clutter.
