### PR TITLE
profiles: disable openmp globally instead of just for boards

### DIFF
--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -19,6 +19,9 @@ USE="${USE} bindist"
 # Namely dhcpcd shoudln't make up random ipv4 addresses using ipv4ll
 USE="${USE} -zeroconf"
 
+# No need for OpenMP support in GCC and other apps
+USE="${USE} -openmp"
+
 # Override upstream's python settings
 USE="$USE python_targets_python2_7 python_single_target_python2_7"
 USE="$USE -python_targets_python3_2 -python_single_target_python3_2"

--- a/profiles/coreos/targets/generic/make.defaults
+++ b/profiles/coreos/targets/generic/make.defaults
@@ -3,7 +3,7 @@
 
 USE="cros-debug acpi usb symlink-usr cryptsetup policykit -pam"
 USE="${USE} -cros_host -expat -cairo -X"
-USE="${USE} -acl -cracklib -gpm -openmp -python -sha512"
+USE="${USE} -acl -cracklib -gpm -python -sha512"
 USE="${USE} -fortran -abiword -perl -cups -poppler-data -nls"
 
 # Exclude documentation


### PR DESCRIPTION
Not a particularly big deal but it seems wise to build the SDK compilers
and the gcc in dev images with the same feature set.
