### PR TITLE
profiles: use go 1.3.1 instead of 1.3

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -105,3 +105,6 @@ dev-util/checkbashisms
 =sys-boot/grub-2.02_beta2
 # current stable xen-tools doesn't build without multilib
 =app-emulation/xen-tools-4.4.0-r9
+
+# 1.3 is marked stable but 1.3.1 hasn't yet
+=dev-lang/go-1.3.1


### PR DESCRIPTION
The current version marked stable in Gentoo is 1.3 but we might as well
bump directly to 1.3.1 instead.
