### PR TITLE
ktop: Install into /usr/sbin, not /usr/local/sbin

### DIFF
--- a/sys-process/ktop/ktop-0.0.1-r17.ebuild
+++ b/sys-process/ktop/ktop-0.0.1-r17.ebuild
@@ -27,5 +27,5 @@ src_compile() {
 }
 
 src_install() {
-	emake install DESTDIR="${D}" || die
+	emake install DESTDIR="${D}" sbindir=/usr/sbin || die
 }

--- a/sys-process/ktop/ktop-9999.ebuild
+++ b/sys-process/ktop/ktop-9999.ebuild
@@ -25,5 +25,5 @@ src_compile() {
 }
 
 src_install() {
-	emake install DESTDIR="${D}" || die
+	emake install DESTDIR="${D}" sbindir=/usr/sbin || die
 }


### PR DESCRIPTION
This preemptively fixes a Gentoo QA warning that will be introduced in
future versions of portage.

Signed-off-by: Richard Yao richard.yao@clusterhq.com
