### PR TITLE
fix for error in public-keys url

### DIFF
--- a/coreos-base/oem-cloudstack/files/cloudstack-ssh-key
+++ b/coreos-base/oem-cloudstack/files/cloudstack-ssh-key
@@ -3,7 +3,7 @@
 . /usr/share/oem/bin/cloudstack-dhcp
 
 DHCP_SERVER=$(get_dhcp_ip)
-KEY_URL="http://${DHCP_SERVER}/latest/meta-data/public-keys"
+KEY_URL="http://${DHCP_SERVER}/latest/public-keys"
 
 block-until-url "${KEY_URL}"
 curl --fail -s "${KEY_URL}" | update-ssh-keys -a cloudstack


### PR DESCRIPTION
The URL used to pull public SSH keys is wrong for Cloudstack. Corrected to the appropriate URL which is: `http://<DHCP SERVER>/latest/public-keys`

Tested in production environment on exoscale public cloud.

NOTE: here are all endpoints available in CloudStack:

```
$ curl --fail -s http://<DHCP SERVER>/latest/
user-data
meta-data
service-offering
availability-zone
local-ipv4
local-hostname
public-ipv4
public-hostname
instance-id
vm-id
public-keys
cloud-identifier
```
