### PR TITLE
Use --convert-netconf=debian when using Openstack config-drive

### DIFF
--- a/coreos-base/oem-ec2-compat/files/cloud-config.yml
+++ b/coreos-base/oem-ec2-compat/files/cloud-config.yml
@@ -15,7 +15,7 @@ coreos:
 
           [Service]
           Type=oneshot
-          ExecStart=/usr/bin/coreos-cloudinit --from-configdrive=/media/configdrive --from-metadata-service
+          ExecStart=/usr/bin/coreos-cloudinit --from-configdrive=/media/configdrive --from-metadata-service @@CONVERT_NETCONF@@
     oem:
       id: @@OEM_ID@@
       name: @@OEM_NAME@@

--- a/coreos-base/oem-ec2-compat/oem-ec2-compat-0.0.3-r1.ebuild
+++ b/coreos-base/oem-ec2-compat/oem-ec2-compat-0.0.3-r1.ebuild
@@ -17,6 +17,7 @@ REQUIRED_USE="^^ ( ec2 openstack brightbox )"
 S="${WORKDIR}"
 
 src_prepare() {
+	CONVERT_NETCONF=""
 	if use ec2 ; then
 		ID="ami"
 		NAME="Amazon EC2"
@@ -25,6 +26,7 @@ src_prepare() {
 		ID="openstack"
 		NAME="Openstack"
 		HOME_URL="https://www.openstack.org/"
+		CONVERT_NETCONF="--convert-netconf=debian"
 	elif use brightbox ; then
 		ID="brightbox"
 		NAME="Brightbox"
@@ -36,6 +38,7 @@ src_prepare() {
 	sed -e "s\\@@OEM_ID@@\\${ID}\\g" \
 	    -e "s\\@@OEM_NAME@@\\${NAME}\\g" \
 	    -e "s\\@@OEM_HOME_URL@@\\${HOME_URL}\\g" \
+	    -e "s\\@@CONVERT_NETCONF@@\\${CONVERT_NETCONF}\\g" \
 	    ${FILESDIR}/cloud-config.yml > ${T}/cloud-config.yml || die
 }
 


### PR DESCRIPTION
When booting CoreOS in an Openstack environment with config-drive,
nova pushes a debian-like network interface configuration file for
cloud-init to read. See:
https://github.com/openstack/nova/blob/master/nova/virt/interfaces.template

This commit modifies the Openstack overlay behavior by adding
--convert-netconf=debian to the cloudinit parameters.
