### PR TITLE
Add minimal OEM packages for Azure and Hyper-V

### DIFF
--- a/coreos-base/oem-azure/files/cloud-config.yml
+++ b/coreos-base/oem-azure/files/cloud-config.yml
@@ -1,0 +1,8 @@
+#cloud-config
+
+coreos:
+    oem:
+      id: azure
+      name: Microsoft Azure
+      home-url: https://azure.microsoft.com/
+      bug-report-url: https://github.com/coreos/bugs/issues

--- a/coreos-base/oem-azure/oem-azure-0.0.1.ebuild
+++ b/coreos-base/oem-azure/oem-azure-0.0.1.ebuild
@@ -1,0 +1,23 @@
+# Copyright (c) 2013 CoreOS, Inc.. All rights reserved.
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+DESCRIPTION="OEM suite for Azure"
+HOMEPAGE=""
+SRC_URI=""
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="amd64"
+IUSE=""
+
+# no source directory
+S="${WORKDIR}"
+
+RDEPEND="dev-lang/python-oem"
+
+src_install() {
+	insinto "/usr/share/oem"
+	doins ${FILESDIR}/cloud-config.yml
+}

--- a/coreos-base/oem-hyperv/files/cloud-config.yml
+++ b/coreos-base/oem-hyperv/files/cloud-config.yml
@@ -1,0 +1,7 @@
+#cloud-config
+
+coreos:
+    oem:
+      id: hyperv
+      name: Microsoft Hyper-V
+      bug-report-url: https://github.com/coreos/bugs/issues

--- a/coreos-base/oem-hyperv/oem-azure-0.0.1.ebuild
+++ b/coreos-base/oem-hyperv/oem-azure-0.0.1.ebuild
@@ -1,0 +1,21 @@
+# Copyright (c) 2013 CoreOS, Inc.. All rights reserved.
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+DESCRIPTION="OEM suite for Hyper-V"
+HOMEPAGE=""
+SRC_URI=""
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="amd64"
+IUSE=""
+
+# no source directory
+S="${WORKDIR}"
+
+src_install() {
+	insinto "/usr/share/oem"
+	doins ${FILESDIR}/cloud-config.yml
+}


### PR DESCRIPTION
We can now can generate images for Azure/Hyper-V, add basic cloud config
to generate /etc/oem-release to identify these images. The Azure images
still lack support for the agent required in that environment.
