### PR TITLE
bash: sync up with latest version in Gentoo

### DIFF
--- a/app-shells/bash/bash-4.2_p48-r2.ebuild
+++ b/app-shells/bash/bash-4.2_p48-r2.ebuild
@@ -1,6 +1,6 @@
 # Copyright 1999-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Header: /var/cvsroot/gentoo-x86/app-shells/bash/bash-4.2_p48.ebuild,v 1.1 2014/09/24 17:23:53 polynomial-c Exp $
+# $Header: /var/cvsroot/gentoo-x86/app-shells/bash/bash-4.2_p48-r1.ebuild,v 1.4 2014/09/25 11:02:20 armin76 Exp $
 
 EAPI="4"
 
@@ -34,7 +34,7 @@ SRC_URI="mirror://gnu/bash/${MY_P}.tar.gz $(patches)"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 ~hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE="afs bashlogger examples mem-scramble +net nls plugins +readline vanilla"
 
 DEPEND=">=sys-libs/ncurses-5.2-r2
@@ -84,6 +84,7 @@ src_prepare() {
 	if ! use vanilla ; then
 		epatch "${FILESDIR}"/${PN}-4.2-speed-up-read-N.patch
 	fi
+	epatch "${FILESDIR}"/bash-eol-pushback.patch #523592
 
 	epatch_user
 }

--- a/app-shells/bash/files/bash-eol-pushback.patch
+++ b/app-shells/bash/files/bash-eol-pushback.patch
@@ -1,0 +1,11 @@
+*** ../bash-20140912/parse.y	2014-08-26 15:09:42.000000000 -0400
+--- parse.y	2014-09-24 22:47:28.000000000 -0400
+***************
+*** 2959,2962 ****
+--- 2959,2964 ----
+    word_desc_to_read = (WORD_DESC *)NULL;
+  
++   eol_ungetc_lookahead = 0;
++ 
+    current_token = '\n';		/* XXX */
+    last_read_token = '\n';


### PR DESCRIPTION
This fixes another piece of the mess but the story isn't over yet.

http://www.openwall.com/lists/oss-security/2014/09/25/10
https://bugs.gentoo.org/show_bug.cgi?id=523592
