### PR TITLE
bash: disable extra performance patches and networking support

### DIFF
--- a/profiles/coreos/targets/generic/package.use
+++ b/profiles/coreos/targets/generic/package.use
@@ -35,3 +35,6 @@ sys-apps/flashrom -dediprog -ft2232_spi -serprog
 
 # break dependency loop between pkg-config and glib
 dev-util/pkgconfig internal-glib
+
+# minimize risk removing unneeded patches and networking support
+app-shells/bash -net vanilla


### PR DESCRIPTION
Killing the performance patch was suggested by @vcaputo and I think we
can go without networking support as well.
