### PR TITLE
profiles: trim more config files from /etc

### DIFF
--- a/profiles/coreos/targets/generic/make.defaults
+++ b/profiles/coreos/targets/generic/make.defaults
@@ -13,13 +13,22 @@ FEATURES="nodoc noinfo noman"
 # Remove bash-completion files as we don't install bash-completion.
 # Remove alternate locales, we only need the standard LANG=C
 INSTALL_MASK="${INSTALL_MASK}
+  /etc/locale.gen
   /usr/share/bash-completion
   /usr/share/gtk-doc
   /usr/share/i18n
   /usr/share/locale
+  /var/db/Makefile
 "
 
 # Exclude assorted config files that we can do without
 INSTALL_MASK="${INSTALL_MASK}
+  /etc/dmtab
+  /etc/e2fsck.conf
+  /etc/lvm/*
+  /etc/mdadm.conf
+  /etc/rsyncd.conf
   /etc/sudoers
+  /etc/wgetrc
+  /etc/xinetd.d
 "


### PR DESCRIPTION
Some of these were deleted by build_image, others were still being
shipped but aren't really needed.

The big question mark is LVM, it isn't clear if LVM's default behavior
is actually sane or if the configs are needed to make it sane. Either
way we were already removing this, but something to note in case issues
crop up eventually.

Depends on https://github.com/coreos/scripts/pull/335
