### PR TITLE
Disable "high performance ssh" openssh patch Gentoo includes

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -51,3 +51,6 @@ dev-libs/glib -mime
 
 # keep grub build simple
 sys-boot/grub -multislot -nls
+
+# disable "high performance ssh" patch
+net-misc/openssh -hpn


### PR DESCRIPTION
Prioritizing security and stability over performance in SSH, omitting
this kind of patch is generally more consistent with our objectives.

Visibly this removes "p1-hpn14v4" from the OpenSSH protocol banner:
SSH-2.0-OpenSSH_6.6p1-hpn14v4

Discussion: https://github.com/coreos/bugs/issues/149
