### PR TITLE
Fixes issue of vagrant not assigned requested IP address.

### DIFF
--- a/coreos-base/oem-vagrant/files/box/configure_networks.rb
+++ b/coreos-base/oem-vagrant/files/box/configure_networks.rb
@@ -117,7 +117,7 @@ module VagrantPlugins
         def self.match_by_name(machine)
           match = {}
           machine.communicate.tap do |comm|
-            comm.sudo("ifconfig -a | grep ^en | cut -f1 -d:") do |_, result|
+            comm.sudo("ifconfig -a | grep '^en\\|^eth' | cut -f1 -d:") do |_, result|
               result.split("\n").each_with_index do |name, interface|
                 match[interface] = "Name=#{name}"
               end


### PR DESCRIPTION
This was caused by the switchover of the network interfaces to ethX format in release 379.0.0 back in July.
User effects are that vagrant was unable to assign the desired address, clusters were probably broken, etc.

Note that vagrant itself has a coreos plugin that is also broken, but this has been overriding it (in a now also broken manner)
