### PR TITLE
open-vm-tools: fix build-time dependencies

### DIFF
--- a/app-emulation/open-vm-tools/open-vm-tools-9.4.6.1770165.ebuild
+++ b/app-emulation/open-vm-tools/open-vm-tools-9.4.6.1770165.ebuild
@@ -22,14 +22,16 @@ SLOT="0"
 KEYWORDS="amd64 ~x86"
 IUSE="+dnet +pic" # TODO: pam
 
-# Dependencies provided by CoreOS, not the OEM:
+DEPEND="dev-libs/glib:2
+	sys-process/procps
+	dnet? ( dev-libs/libdnet )"
+
+# Runtime dependencies provided by CoreOS, not the OEM:
 #	dev-libs/glib:2
 #	sys-apps/ethtool
 #	sys-process/procps
 #	pam? ( virtual/pam )
-RDEPEND="
-	dnet? ( dev-libs/libdnet )
-"
+RDEPEND="dnet? ( dev-libs/libdnet )"
 
 S="${WORKDIR}/${MY_P}"
 


### PR DESCRIPTION
Although we don't want glib and procps to be in the runtime dependencies
due to the way OEM packages are handled we still want them included as
build-time dependencies so compilation is actually successful. :)
