### PR TITLE
grub: mark new version as stable

### DIFF
--- a/sys-boot/grub/grub-2.02_beta2_p20141106.ebuild
+++ b/sys-boot/grub/grub-2.02_beta2_p20141106.ebuild
@@ -1,0 +1,1 @@
+grub-9999.ebuild


### PR DESCRIPTION
This is the first stable ebuild using our own grub git repo which
includes support for the `linuxefi` command, required for using grub
with Fedora's shim and UEFI secure boot. Includes other minor updates
since the snapshot cut used by the previous stable ebuild:
