### PR TITLE
grub: mark new version as stable

### DIFF
--- a/sys-boot/grub/grub-2.02_beta2_p20141106.ebuild
+++ b/sys-boot/grub/grub-2.02_beta2_p20141106.ebuild
@@ -1,0 +1,1 @@
+grub-9999.ebuild

--- a/sys-boot/grub/grub-9999.ebuild
+++ b/sys-boot/grub/grub-9999.ebuild
@@ -12,7 +12,7 @@ PYTHON_COMPAT=( python{2_6,2_7,3_2,3_3,3_4} )
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~x86"
 else
-	CROS_WORKON_COMMIT="x"
+	CROS_WORKON_COMMIT="7ed934533c1319954540f6cee0c0bf728b155c2e"
 	KEYWORDS="amd64 x86"
 fi
 


### PR DESCRIPTION
This is the first stable ebuild using our own grub git repo which
includes support for the `linuxefi` command, required for using grub
with Fedora's shim and UEFI secure boot. Includes other minor updates
since the snapshot cut used by the previous stable ebuild:

```
Andrei Borzenkov (1):
      Use full initializer for initrd_ctx to avoid fatal warnings with older GCC

Andrey Borzenkov (1):
      cleanup: grub_cpu_to_XXX_compile_time for constants

Colin Watson (5):
      * configure.ac: Remove several unnecessary semicolons.
      Support grub-emu on x32 (ILP32 but with x86-64 instruction set)
      Tidy up ChangeLog formatting.
      Add a new "none" platform that only builds utilities
      Fix in-tree --platform=none

Khem Raj (1):
      Fix build with glibc 2.20

Matthew Garrett (1):
      Add support for linuxefi

Michael Chang (2):
      Fix incorrect address reference in btrfs
      * grub-core/osdep/unix/config.c: Remove extraneous comma.

Michael Marineau (12):
      linguas: use en_US as UTF-8 locale, C.UTF-8 is not a standard locale.
      gpt: start new GPT module
      tests: fix path to words file on Gentoo/CoreOS
      gpt: rename misnamed header location fields
      gpt: record size of of the entries table
      gpt: consolidate crc32 computation code
      gpt: add new repair function to sync up primary and backup tables.
      gpt: add write function and gptrepair command

Peter Jones (1):
      Initialized initrd_ctx so we don't free a random pointer from the stack.

Valentin Dornauer (1):
      ACPIhalt: Add more ACPI opcodes.

Vladimir Serbinenko (5):
      Fix wrong commit
      * grub-core/gmodule.pl.in: Accept newer binutils which output
        empty column rather than 0x0.
      * grub-core/commands/keylayouts.c: Ignore unknown keys.
      * grub-core/normal/main.c: Don't drop to rescue console in
        case of password-protected prompt and no menu entries.
      Revert "Use -Wl,--no-relax rather than -mno-relax for uniformity."
```
