### PR TITLE
add patch to set USE_SLASH_PROC macro

### DIFF
--- a/app-emulation/open-vm-tools/files/open-vm-tools-9.4.6-1770165-0005-define_USE_SLASH_PROC.patch
+++ b/app-emulation/open-vm-tools/files/open-vm-tools-9.4.6-1770165-0005-define_USE_SLASH_PROC.patch
@@ -1,0 +1,24 @@
+From 5936cd877fd307b796e364a4ac99615f44ef6024 Mon Sep 17 00:00:00 2001
+From: Oliver Kurth <okurth@vmware.com>
+Date: Mon, 17 Nov 2014 17:36:52 -0800
+Subject: [PATCH] define USE_SLASH_PROC
+
+---
+ open-vm-tools/services/plugins/guestInfo/getlib/Makefile.am | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/open-vm-tools/services/plugins/guestInfo/getlib/Makefile.am b/open-vm-tools/services/plugins/guestInfo/getlib/Makefile.am
+index 331e24f..862029f 100644
+--- a/open-vm-tools/services/plugins/guestInfo/getlib/Makefile.am
++++ b/open-vm-tools/services/plugins/guestInfo/getlib/Makefile.am
+@@ -28,4 +28,6 @@ libGuestInfo_la_CPPFLAGS += @GLIB2_CPPFLAGS@
+ libGuestInfo_la_CPPFLAGS += -I$(srcdir)/..
+
+ AM_CFLAGS = $(DNET_CPPFLAGS)
+-
++if USE_SLASH_PROC
++AM_CFLAGS += -DUSE_SLASH_PROC
++endif
+-- 
+1.9.1
+

--- a/app-emulation/open-vm-tools/open-vm-tools-9.4.6.1770165-r1.ebuild
+++ b/app-emulation/open-vm-tools/open-vm-tools-9.4.6.1770165-r1.ebuild
@@ -40,6 +40,7 @@ PATCHES=(
 	"${FILESDIR}/${MY_P}-0002-configure-Fix-USE_SLASH_PROC-conditional.patch"
 	"${FILESDIR}/${MY_P}-0003-scripts-Remove-ifup.patch"
 	"${FILESDIR}/${MY_P}-0004-auth-Read-from-shadow.patch"
+	"${FILESDIR}/${MY_P}-0005-define_USE_SLASH_PROC.patch"
 )
 
 #pkg_setup() {


### PR DESCRIPTION
This adds a fix to use functions from procps to determine routing information. I thought this was fixed with open-vm-tools-9.4.6-1770165-0002-configure-Fix-USE_SLASH_PROC-conditional.patch , but that alone was not enough.

The issue can be verified with the command on the ESXi console (or with Workstation/Fusion with vmware-vim-cmd if the vm is shared):
vim-cmd  vmsvc/get.guest <id>

This should not be empty, and actually show the routing table:

```
     ipRouteConfig = (vim.net.IpRouteConfigInfo) {
        ipRoute = (vim.net.IpRouteConfigInfo.IpRoute) [
           (vim.net.IpRouteConfigInfo.IpRoute) {
              network = "0.0.0.0", 
              prefixLength = 0, 
              gateway = (vim.net.IpRouteConfigInfo.Gateway) {
                 ipAddress = "10.20.95.253", 
                 device = "0"
              }
           }, 
```

...
