### PR TITLE
flannel: plumb --etcd-endpoints to an environment variable.

### DIFF
--- a/app-admin/flannel/files/flanneld.service
+++ b/app-admin/flannel/files/flanneld.service
@@ -11,11 +11,12 @@ Type=notify
 Environment="TMPDIR=/var/tmp/"
 Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
 Environment="FLANNEL_VER={{flannel_ver}}"
+Environment="ETCD_ENDPOINT=http://127.0.0.1:4001"
 LimitNOFILE=1048576
 LimitNPROC=1048576
 ExecStartPre=/usr/bin/mkdir -p /run/flannel
 
-ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock /usr/bin/docker run --net=host --privileged=true --rm -v /run/flannel:/run/flannel -e NOTIFY_SOCKET=/run/flannel/sd.sock quay.io/coreos/flannel:${FLANNEL_VER} /opt/bin/flanneld --ip-masq=true
+ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock /usr/bin/docker run --net=host --privileged=true --rm -v /run/flannel:/run/flannel -e NOTIFY_SOCKET=/run/flannel/sd.sock quay.io/coreos/flannel:${FLANNEL_VER} /opt/bin/flanneld --ip-masq=true --etcd-endpoint=${ETCD_ENDPOINT}
 
 # Update docker options
 ExecStartPost=/bin/bash -c '    \


### PR DESCRIPTION
This makes it easy to connect flannel to an HTTPS etcd, without
having to rewrite the entire docker commandline.