### PR TITLE
sys-apps/systemd: mark /var/log/journal as no copy-on-write

### DIFF
--- a/sys-apps/systemd/systemd-215-r16.ebuild
+++ b/sys-apps/systemd/systemd-215-r16.ebuild
@@ -491,6 +491,9 @@ pkg_postinst() {
 	# Migrate 80-net-name-slot.rules -> 80-net-setup-link.rules
 	migrate_net_name_slot
 
+	# Mark journald log directory as no copy-on-write
+	chattr +C /var/log/journal
+
 	if [[ ${FAIL} ]]; then
 		eerror "One of the postinst commands failed. Please check the postinst output"
 		eerror "for errors. You may need to clean up your system and/or try installing"


### PR DESCRIPTION
This should set the nocow flag on the journald log dir (/var/log/journal) as per https://groups.google.com/forum/#!topic/coreos-dev/X4RyCEuHp18
