### PR TITLE
profiles: fix stage1 bootstrap builds

### DIFF
--- a/profiles/features/systemd/package.use.force
+++ b/profiles/features/systemd/package.use.force
@@ -1,0 +1,8 @@
+# Copyright (c) 2014 The CoreOS Authors. All rights reserved.
+# Distributed under the terms of the GNU General Public License v2
+
+# disable gentoo-only bits
+sys-apps/systemd vanilla
+
+# dbus without systemd conflicts with systemd
+sys-apps/dbus systemd


### PR DESCRIPTION
Prevent pulling in 'gentoo-systemd-integration' and ensure dbus is
always built with systemd support.
