### PR TITLE
profiles: enable ipc and network sandboxing

### DIFF
--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -74,7 +74,8 @@ CCACHE_SIZE="2.5G"
 
 # Always build binary packages, remove old build logs, avoid running as root.
 FEATURES="buildpkg ccache clean-logs compressdebug parallel-install splitdebug
-          userfetch userpriv usersandbox -merge-sync"
+          userfetch userpriv usersandbox ipc-sandbox network-sandbox
+          -merge-sync"
 
 # No need to restrict access to build directories in dev environments.
 PORTAGE_WORKDIR_MODE="0755"


### PR DESCRIPTION
Another day, another intermittent build failure because the local xml
docbook catalog didn't work right and the xml parser also failed to
fetch the schema over the network. Configure portage to use network
namespaces to prevent such situations from ever working in the first
place so at least the errors are unlikely to be intermittent.

For the sake of completeness use ipc namespaces too but that is less
likely to actually be a factor in our builds.
