### PR TITLE
systemd: fix build depends for patched sources

### DIFF
--- a/sys-apps/systemd/systemd-217-r4.ebuild
+++ b/sys-apps/systemd/systemd-217-r4.ebuild
@@ -99,12 +99,15 @@ DEPEND="${COMMON_DEPEND}
 	python? ( dev-python/lxml[${PYTHON_USEDEP}] )
 	test? ( >=sys-apps/dbus-1.6.8-r1:0 )"
 
-if [[ ${PV} == *9999 ]]; then
+# Only required if patches touch man page source xml, which is usually.
 DEPEND="${DEPEND}
 	app-text/docbook-xml-dtd:4.2
 	app-text/docbook-xml-dtd:4.5
 	app-text/docbook-xsl-stylesheets
-	dev-libs/libxslt:0
+	dev-libs/libxslt:0"
+
+if [[ ${PV} == *9999 ]]; then
+DEPEND="${DEPEND}
 	dev-libs/gobject-introspection
 	>=dev-libs/libgcrypt-1.4.5:0"
 

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -98,12 +98,15 @@ DEPEND="${COMMON_DEPEND}
 	python? ( dev-python/lxml[${PYTHON_USEDEP}] )
 	test? ( >=sys-apps/dbus-1.6.8-r1:0 )"
 
-if [[ ${PV} == *9999 ]]; then
+# Only required if patches touch man page source xml, which is usually.
 DEPEND="${DEPEND}
 	app-text/docbook-xml-dtd:4.2
 	app-text/docbook-xml-dtd:4.5
 	app-text/docbook-xsl-stylesheets
-	dev-libs/libxslt:0
+	dev-libs/libxslt:0"
+
+if [[ ${PV} == *9999 ]]; then
+DEPEND="${DEPEND}
 	dev-libs/gobject-introspection
 	>=dev-libs/libgcrypt-1.4.5:0"
 


### PR DESCRIPTION
Patches routinely modify the man page source XML, invalidating the
prebuilt man pages provided by release tarballs. Patch the live ebuild
too and require the docbook XML DTDs unconditionally like we did for 215
all the time going forward so this issue isn't forgotten again during
the next version bump.

No need to bump the ebuild revision since the change only impacts a build-time issue.
