### PR TITLE
profiles: upgrade lbzip2 to 2.5

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -106,3 +106,6 @@ dev-util/checkbashisms
 # https://www.openssl.org/news/secadv_20141015.txt
 # https://bugs.gentoo.org/show_bug.cgi?id=525468
 =dev-libs/openssl-1.0.1j
+
+# Fixes a few bugs but has not yet been marked stable upstream.
+=app-arch/lbzip2-2.5


### PR DESCRIPTION
This release contains a few bugfixes, which may or may not be related to
the intermittent tar related failures we have often had.
