### PR TITLE
coreos-kernel: bump to 3.17.7

### DIFF
--- a/sys-kernel/coreos-kernel/coreos-kernel-3.17.7.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-3.17.7.ebuild
@@ -3,7 +3,7 @@
 # $Header: /var/cvsroot/gentoo-x86/sys-kernel/vanilla-sources/vanilla-sources-3.7.5.ebuild,v 1.1 2013/01/28 13:18:54 ago Exp $
 
 EAPI=5
-CROS_WORKON_COMMIT="906d77a3c6c0578ccb1834875ab53360777b7ff3" # v3.17.2
+CROS_WORKON_COMMIT="9fbe8b46fa4bb64f8f4f1abcb03d03e92de2aafb" # v3.17.7
 CROS_WORKON_REPO="git://github.com"
 CROS_WORKON_PROJECT="coreos/linux"
 CROS_WORKON_LOCALNAME="linux"

--- a/sys-kernel/coreos-kernel/files/x86_64_defconfig-3.17.7
+++ b/sys-kernel/coreos-kernel/files/x86_64_defconfig-3.17.7
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 3.17.2 Kernel Configuration
+# Linux/x86 3.17.7 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y
@@ -2918,7 +2918,6 @@ CONFIG_RTC_DRV_CMOS=y
 # CONFIG_RTC_DRV_DS1553 is not set
 # CONFIG_RTC_DRV_DS1742 is not set
 # CONFIG_RTC_DRV_DS2404 is not set
-# CONFIG_RTC_DRV_EFI is not set
 # CONFIG_RTC_DRV_STK17TA8 is not set
 # CONFIG_RTC_DRV_M48T86 is not set
 # CONFIG_RTC_DRV_M48T35 is not set


### PR DESCRIPTION
Note: this config does not include any changes we've made since cutting the build-522 branch to minimize changes in beta/stable.
