### PR TITLE
coreos-init: fix revision symlink

### DIFF
--- a/coreos-base/coreos-init/coreos-init-0.0.1-r104.ebuild
+++ b/coreos-base/coreos-init/coreos-init-0.0.1-r104.ebuild
@@ -1,0 +1,1 @@
+coreos-init-9999.ebuild


### PR DESCRIPTION
Dropped instead of renamed by accident.
