### PR TITLE
ntp: sync updates from upstream, replace 'examples' use flag with 'perl'

### DIFF
--- a/net-misc/ntp/files/ntp-4.2.8-disable-perl-scripts.patch
+++ b/net-misc/ntp/files/ntp-4.2.8-disable-perl-scripts.patch
@@ -1,0 +1,24 @@
+From 7c3b3f34f94146d5178adee4c5a184e9b1546e89 Mon Sep 17 00:00:00 2001
+From: Michael Marineau <mike@marineau.org>
+Date: Mon, 22 Dec 2014 21:20:46 -0800
+Subject: [PATCH] disable perl scripts
+
+---
+ Makefile.am | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index fc76719..1fd008d 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -6,7 +6,6 @@ NULL =
+ 
+ SUBDIRS =		\
+ 	sntp		\
+-	scripts		\
+ 	include		\
+ 	libntp		\
+ 	libparse	\
+-- 
+2.0.4
+

--- a/net-misc/ntp/files/ntp-4.2.8-ntp-keygen-no-openssl.patch
+++ b/net-misc/ntp/files/ntp-4.2.8-ntp-keygen-no-openssl.patch
@@ -1,0 +1,164 @@
+Fix ntp-keygen build without OpenSSL
+
+Upstream commit:
+http://bk1.ntp.org/ntp-stable/?PAGE=patch&REV=5497b345z5MNTuNvJWuqPSje25NQTg
+Gentoo bugzilla: https://bugs.gentoo.org/show_bug.cgi?id=533238
+
+Signed-off-by: Markos Chandras <hwoarang@gentoo.org>
+Index: ntp-4.2.8/Makefile.am
+===================================================================
+--- ntp-4.2.8.orig/Makefile.am
++++ ntp-4.2.8/Makefile.am
+@@ -2,7 +2,10 @@ ACLOCAL_AMFLAGS = -I sntp/m4 -I sntp/lib
+ 
+ NULL =
+ 
++# moved sntp first to get libtool and libevent built.
++
+ SUBDIRS =		\
++	sntp		\
+ 	scripts		\
+ 	include		\
+ 	libntp		\
+@@ -17,7 +20,6 @@ SUBDIRS =		\
+ 	clockstuff	\
+ 	kernel		\
+ 	util		\
+-	sntp		\
+ 	tests		\
+ 	$(NULL)
+ 
+@@ -64,7 +66,6 @@ BUILT_SOURCES =				\
+ 	.gcc-warning			\
+ 	libtool				\
+ 	html/.datecheck			\
+-	sntp/built-sources-only		\
+ 	$(srcdir)/COPYRIGHT		\
+ 	$(srcdir)/.checkChangeLog	\
+ 	$(NULL)
+Index: ntp-4.2.8/configure.ac
+===================================================================
+--- ntp-4.2.8.orig/configure.ac
++++ ntp-4.2.8/configure.ac
+@@ -102,7 +102,7 @@ esac
+ enable_nls=no
+ LIBOPTS_CHECK_NOBUILD([sntp/libopts])
+ 
+-NTP_ENABLE_LOCAL_LIBEVENT
++NTP_LIBEVENT_CHECK_NOBUILD([2], [sntp/libevent])
+ 
+ NTP_LIBNTP
+ 
+@@ -771,6 +771,10 @@ esac
+ 
+ #### 
+ 
++AC_CHECK_FUNCS([arc4random_buf])
++
++#### 
++
+ saved_LIBS="$LIBS"
+ LIBS="$LIBS $LDADD_LIBNTP"
+ AC_CHECK_FUNCS([daemon])
+Index: ntp-4.2.8/libntp/ntp_crypto_rnd.c
+===================================================================
+--- ntp-4.2.8.orig/libntp/ntp_crypto_rnd.c
++++ ntp-4.2.8/libntp/ntp_crypto_rnd.c
+@@ -24,6 +24,21 @@
+ int crypto_rand_init = 0;
+ #endif
+ 
++#ifndef HAVE_ARC4RANDOM_BUF
++static void
++arc4random_buf(void *buf, size_t nbytes);
++
++void
++evutil_secure_rng_get_bytes(void *buf, size_t nbytes);
++
++static void
++arc4random_buf(void *buf, size_t nbytes)
++{
++	evutil_secure_rng_get_bytes(buf, nbytes);
++	return;
++}
++#endif
++
+ /*
+  * As of late 2014, here's how we plan to provide cryptographic-quality
+  * random numbers:
+Index: ntp-4.2.8/sntp/configure.ac
+===================================================================
+--- ntp-4.2.8.orig/sntp/configure.ac
++++ ntp-4.2.8/sntp/configure.ac
+@@ -97,11 +97,14 @@ esac
+ enable_nls=no
+ LIBOPTS_CHECK
+ 
+-AM_COND_IF(
+-    [BUILD_SNTP],
+-    [NTP_LIBEVENT_CHECK],
+-    [NTP_LIBEVENT_CHECK_NOBUILD]
+-)
++# From when we only used libevent for sntp:
++#AM_COND_IF(
++#    [BUILD_SNTP],
++#    [NTP_LIBEVENT_CHECK],
++#    [NTP_LIBEVENT_CHECK_NOBUILD]
++#)
++
++NTP_LIBEVENT_CHECK([2])
+ 
+ # Checks for libraries.
+ 
+Index: ntp-4.2.8/sntp/m4/ntp_libevent.m4
+===================================================================
+--- ntp-4.2.8.orig/sntp/m4/ntp_libevent.m4
++++ ntp-4.2.8/sntp/m4/ntp_libevent.m4
+@@ -1,4 +1,25 @@
+-dnl NTP_ENABLE_LOCAL_LIBEVENT				     -*- Autoconf -*-
++# SYNOPSIS						-*- Autoconf -*-
++#
++#  NTP_ENABLE_LOCAL_LIBEVENT
++#  NTP_LIBEVENT_CHECK([MINVERSION [, DIR]])
++#  NTP_LIBEVENT_CHECK_NOBUILD([MINVERSION [, DIR]])
++#
++# DESCRIPTION
++#
++# AUTHOR
++#
++#  Harlan Stenn
++#
++# LICENSE
++#
++#  This file is Copyright (c) 2014 Network Time Foundation
++# 
++#  Copying and distribution of this file, with or without modification, are
++#  permitted in any medium without royalty provided the copyright notice,
++#  author attribution and this notice are preserved.  This file is offered
++#  as-is, without any warranty.
++
++dnl NTP_ENABLE_LOCAL_LIBEVENT
+ dnl
+ dnl Provide only the --enable-local-libevent command-line option.
+ dnl
+@@ -29,7 +50,7 @@ dnl If NOBUILD is provided as the 3rd ar
+ dnl but DO NOT invoke DIR/configure if we are going to use our bundled
+ dnl version.  This may be the case for nested packages.
+ dnl
+-dnl provide --enable-local-libevent .
++dnl provides --enable-local-libevent .
+ dnl
+ dnl Examples:
+ dnl
+Index: ntp-4.2.8/util/Makefile.am
+===================================================================
+--- ntp-4.2.8.orig/util/Makefile.am
++++ ntp-4.2.8/util/Makefile.am
+@@ -19,6 +19,7 @@ AM_LDFLAGS = $(LDFLAGS_NTP)
+ LDADD=		../libntp/libntp.a $(LDADD_LIBNTP) $(LIBM) $(PTHREAD_LIBS)
+ tg2_LDADD=	../libntp/libntp.a $(LDADD_LIBNTP) $(LIBM)
+ ntp_keygen_LDADD  = version.o $(LIBOPTS_LDADD) ../libntp/libntp.a
++ntp_keygen_LDADD += $(LDADD_LIBEVENT)
+ ntp_keygen_LDADD += $(LDADD_LIBNTP) $(PTHREAD_LIBS) $(LDADD_NTP) $(LIBM)
+ ntp_keygen_SOURCES = ntp-keygen.c ntp-keygen-opts.c ntp-keygen-opts.h
+ 


### PR DESCRIPTION
Some minor updates from upstream such as a fix for building without
openssl which doesn't impact our current configuration. Additionally,
our 'examples' use flag was non-functional because 4.2.8 now includes
scripts in its normal build system and installs them to bin. Instead add
a better named 'perl' use flag and patch the build.
