### PR TITLE
hard-host-depends: temporary fix for upgrading @system

### DIFF
--- a/coreos-base/hard-host-depends/hard-host-depends-0.0.1-r170.ebuild
+++ b/coreos-base/hard-host-depends/hard-host-depends-0.0.1-r170.ebuild
@@ -1,0 +1,1 @@
+hard-host-depends-0.0.1.ebuild


### PR DESCRIPTION
The `build_toolchains` process upgrades the @system package set rather
than @world before building the cross toolchains. This means systemd
will be upgraded, replacing systemd-sysv-utils, but not
hard-host-depends which previously depended on systemd-sysv-utils.
Mixing the older hard-host-depends with the latest systemd creates a
conflict. Fortunately we can work around this by providing the older
ebuild revision with the newer dependency list. Portage will use the
dependency list from the ebuild rather than the installed package.

`hard-host-depends-0.0.1-r170.ebuild` can be removed once the SDK
version is 457.0.0 or later.
