### PR TITLE
systemd: copy symlink-usr handling from old systemd-sysv-utils ebuild

### DIFF
--- a/sys-apps/systemd/systemd-218-r2.ebuild
+++ b/sys-apps/systemd/systemd-218-r2.ebuild
@@ -38,8 +38,8 @@ IUSE="acl apparmor audit cryptsetup curl doc elfutils gcrypt gudev http
 	idn introspection kdbus +kmod lz4 lzma pam policykit python qrcode +seccomp
 	selinux ssl sysv-utils terminal test vanilla xkb"
 
-# Gentoo removed this use flag, we'll keep it for now
-IUSE+=" nls"
+# Gentoo removed the nls use flag, we'll keep it for now
+IUSE+=" nls symlink-usr"
 
 MINKV="3.8"
 
@@ -372,10 +372,12 @@ multilib_src_install_all() {
 	einstalldocs
 
 	if use sysv-utils; then
+		local prefix
+		use symlink-usr && prefix=/usr
 		for app in halt poweroff reboot runlevel shutdown telinit; do
-			dosym "..${ROOTPREFIX-/usr}/bin/systemctl" /sbin/${app}
+			dosym /usr/bin/systemctl ${prefix}/sbin/${app}
 		done
-		dosym "..${ROOTPREFIX-/usr}/lib/systemd/systemd" /sbin/init
+		dosym /usr/lib/systemd/systemd ${prefix}/sbin/init
 	else
 		# we just keep sysvinit tools, so no need for the mans
 		rm "${D}"/usr/share/man/man8/{halt,poweroff,reboot,runlevel,shutdown,telinit}.8 \

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -38,8 +38,8 @@ IUSE="acl apparmor audit cryptsetup curl doc elfutils gcrypt gudev http
 	idn introspection kdbus +kmod lz4 lzma pam policykit python qrcode +seccomp
 	selinux ssl sysv-utils terminal test vanilla xkb"
 
-# Gentoo removed this use flag, we'll keep it for now
-IUSE+=" nls"
+# Gentoo removed the nls use flag, we'll keep it for now
+IUSE+=" nls symlink-usr"
 
 MINKV="3.8"
 
@@ -368,10 +368,12 @@ multilib_src_install_all() {
 	einstalldocs
 
 	if use sysv-utils; then
+		local prefix
+		use symlink-usr && prefix=/usr
 		for app in halt poweroff reboot runlevel shutdown telinit; do
-			dosym "..${ROOTPREFIX-/usr}/bin/systemctl" /sbin/${app}
+			dosym /usr/bin/systemctl ${prefix}/sbin/${app}
 		done
-		dosym "..${ROOTPREFIX-/usr}/lib/systemd/systemd" /sbin/init
+		dosym /usr/lib/systemd/systemd ${prefix}/sbin/init
 	else
 		# we just keep sysvinit tools, so no need for the mans
 		rm "${D}"/usr/share/man/man8/{halt,poweroff,reboot,runlevel,shutdown,telinit}.8 \


### PR DESCRIPTION
While moving from systemd-sysv-utils to systemd w/ USE=sysv-utils I
forgot that USE=symlink-usr needed special handling to ensure the
symlinks were created correctly.