### PR TITLE
profiles: revert go to 1.3

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -112,6 +112,3 @@ dev-util/checkbashisms
 
 # >=3.16 required by docker 1.4
 =sys-fs/btrfs-progs-3.17.1
-
-# Lets give go 1.4 a spin!
-=dev-lang/go-1.4


### PR DESCRIPTION
We aren't ready to bump to go1.4 due to a docker-related issue. docker is failing with:

```
Jan 02 01:49:42 ip-10-81-162-79.ec2.internal dockerd[682]: SQL error or missing database: cannot start a transaction within a transaction
```

Maybe related: https://github.com/docker/docker/pull/9615/files#r22109378

This PR is a straight revert of 3e2bf774b501e7fb4363286663b50d77c3a7bf45