### PR TITLE
coreos-kernel: Fix kernel builds, broken by update to ccache 3.2.1

### DIFF
--- a/eclass/coreos-kernel.eclass
+++ b/eclass/coreos-kernel.eclass
@@ -84,6 +84,11 @@ update_bootengine_cpio() {
 
 kmake() {
 	local kernel_arch=$(tc-arch-kernel)
+	# Disable hardened PIE explicitly, >=ccache-3.2 breaks the hardened
+	# compiler's auto-detection of kernel builds.
+	if gcc-specs-pie; then
+		set -- KCFLAGS=-nopie "$@"
+	fi
 	emake ARCH="${kernel_arch}" CROSS_COMPILE="${CHOST}-" "$@"
 }
 


### PR DESCRIPTION
Apparently didn't recompile enough stuff to test the ccache change. From
the ccache 3.2 release notes:

    ccache no longer passes preprocessor options like -D and -I to the
    compiler when compiling preprocessed output. This fixes warnings
    emitted by clang.

The hardened compiler, at least as of gcc-4.8.3, uses -D__KERNEL__ to
detect kernel compiles and in that case avoids enabling PIE by default.
Mixing PIE and kernel compiles can lead to the following error:

    error: code model kernel does not support PIC mode

Upstream bug: https://bugs.gentoo.org/show_bug.cgi?id=535984