### PR TITLE
systemd: Accept DHCP domains with a trailing dot

### DIFF
--- a/sys-apps/systemd/files/218-0001-networkd-accept-a-trailing-.-on-the-end-of-domains.patch
+++ b/sys-apps/systemd/files/218-0001-networkd-accept-a-trailing-.-on-the-end-of-domains.patch
@@ -1,0 +1,118 @@
+From 846415f22adc23ceba5831301433d3587a871697 Mon Sep 17 00:00:00 2001
+From: Michael Marineau <michael.marineau@coreos.com>
+Date: Thu, 15 Jan 2015 13:02:48 -0800
+Subject: [PATCH] networkd: accept a trailing '.' on the end of domains
+
+While not common outside of BIND configs the implied top level '.' in
+domains is commonly accepted and crops up in random places. Starting
+with commit 784d9b9c networkd began validating domains as hostnames
+which rejects trailing dots, breaking short name resolution in some
+environments such as Google Compute Engine. This change splits the
+validation code into two functions to be more tolerant for domains.
+---
+ src/libsystemd-network/sd-dhcp-lease.c |  2 +-
+ src/network/networkd-network.c         |  2 +-
+ src/shared/util.c                      | 13 ++++++++++---
+ src/shared/util.h                      |  1 +
+ src/test/test-util.c                   | 14 ++++++++++++++
+ 5 files changed, 27 insertions(+), 5 deletions(-)
+
+diff --git a/src/libsystemd-network/sd-dhcp-lease.c b/src/libsystemd-network/sd-dhcp-lease.c
+index 22a4af6..8144061 100644
+--- a/src/libsystemd-network/sd-dhcp-lease.c
++++ b/src/libsystemd-network/sd-dhcp-lease.c
+@@ -502,7 +502,7 @@ int dhcp_lease_parse_options(uint8_t code, uint8_t len, const uint8_t *option,
+                 if (r < 0)
+                         return r;
+ 
+-                if (!hostname_is_valid(domainname) || is_localhost(domainname))
++                if (!domainname_is_valid(domainname) || is_localhost(domainname))
+                         break;
+ 
+                 free(lease->domainname);
+diff --git a/src/network/networkd-network.c b/src/network/networkd-network.c
+index ef9e0a8..c13c731 100644
+--- a/src/network/networkd-network.c
++++ b/src/network/networkd-network.c
+@@ -392,7 +392,7 @@ int config_parse_domains(const char *unit,
+         STRV_FOREACH(domain, *domains) {
+                 if (is_localhost(*domain))
+                         log_syntax(unit, LOG_ERR, filename, line, EINVAL, "'localhost' domain names may not be configured, ignoring assignment: %s", *domain);
+-                else if (!hostname_is_valid(*domain)) {
++                else if (!domainname_is_valid(*domain)) {
+                         if (!streq(*domain, "*"))
+                                 log_syntax(unit, LOG_ERR, filename, line, EINVAL, "domain name is not valid, ignoring assignment: %s", *domain);
+                 } else
+diff --git a/src/shared/util.c b/src/shared/util.c
+index 26a4f72..736a3dd 100644
+--- a/src/shared/util.c
++++ b/src/shared/util.c
+@@ -4170,7 +4170,7 @@ static bool hostname_valid_char(char c) {
+                 c == '.';
+ }
+ 
+-bool hostname_is_valid(const char *s) {
++bool domainname_is_valid(const char *s) {
+         const char *p;
+         bool dot;
+ 
+@@ -4191,10 +4191,17 @@ bool hostname_is_valid(const char *s) {
+                 }
+         }
+ 
+-        if (dot)
++        if (p-s > HOST_NAME_MAX)
+                 return false;
+ 
+-        if (p-s > HOST_NAME_MAX)
++        return true;
++}
++
++bool hostname_is_valid(const char *s) {
++        if (!domainname_is_valid(s))
++                return false;
++
++        if (s[strlen(s)-1] == '.')
+                 return false;
+ 
+         return true;
+diff --git a/src/shared/util.h b/src/shared/util.h
+index 73bd901..87cdac5 100644
+--- a/src/shared/util.h
++++ b/src/shared/util.h
+@@ -542,6 +542,7 @@ bool nulstr_contains(const char*nulstr, const char *needle);
+ bool plymouth_running(void);
+ 
+ bool hostname_is_valid(const char *s) _pure_;
++bool domainname_is_valid(const char *s) _pure_;
+ char* hostname_cleanup(char *s, bool lowercase);
+ 
+ bool machine_name_is_valid(const char *s) _pure_;
+diff --git a/src/test/test-util.c b/src/test/test-util.c
+index fe54586..b334d38 100644
+--- a/src/test/test-util.c
++++ b/src/test/test-util.c
+@@ -479,6 +479,20 @@ static void test_hostname_is_valid(void) {
+         assert_se(!hostname_is_valid("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"));
+ }
+ 
++static void test_domainname_is_valid(void) {
++        assert_se(domainname_is_valid("foobar"));
++        assert_se(domainname_is_valid("foobar."));
++        assert_se(domainname_is_valid("foobar.com"));
++        assert_se(domainname_is_valid("foobar.com."));
++        assert_se(!domainname_is_valid("fööbar"));
++        assert_se(!domainname_is_valid(""));
++        assert_se(!domainname_is_valid("."));
++        assert_se(!domainname_is_valid(".."));
++        assert_se(!domainname_is_valid(".foobar"));
++        assert_se(!domainname_is_valid("foo..bar"));
++        assert_se(!domainname_is_valid("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"));
++}
++
+ static void test_u64log2(void) {
+         assert_se(u64log2(0) == 0);
+         assert_se(u64log2(8) == 3);
+-- 
+2.0.5
+

--- a/sys-apps/systemd/systemd-218-r3.ebuild
+++ b/sys-apps/systemd/systemd-218-r3.ebuild
@@ -177,6 +177,9 @@ fi
 	cp "${FILESDIR}"/217-systemd-consoled.service.in \
 		units/user/systemd-consoled.service.in || die
 
+	# https://github.com/coreos/bugs/issues/220
+	epatch "${FILESDIR}"/218-0001-networkd-accept-a-trailing-.-on-the-end-of-domains.patch
+
 	autotools-utils_src_prepare
 }
 


### PR DESCRIPTION
GCE includes the BIND-ism trailing '.' at the end of the domain name
reported in DHCP leases. After 215 systemd started rejecting this.
Fixes a regression compared to the current CoreOS stable release.

Fixes https://github.com/coreos/bugs/issues/220