### PR TITLE
profiles: use glibc-2.17 for now

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -112,3 +112,5 @@ dev-util/checkbashisms
 
 # >=3.16 required by docker 1.4
 =sys-fs/btrfs-progs-3.17.1
+
+=sys-libs/glibc-2.17


### PR DESCRIPTION
Machines with glibc-2.17 had trouble upgrading to a build with glibc-2.19.
```
/tmp/au_postint_mount.M1lgpn/bin/cgpt: relocation error: /tmp/au_postint_mount.M1lgpn/lib/libc.so.6: symbol _dl_find_dso_for_object, version GLIBC_PRIVATE not defined in file ld-linux-x86-64.so.2 with link time reference
```

Let's roll this back to 2.17 for now.