### PR TITLE
sys-apps/systemd: add patch for nspawn module load

### DIFF
--- a/sys-apps/systemd/files/218-0002-allow-module-loading.patch
+++ b/sys-apps/systemd/files/218-0002-allow-module-loading.patch
@@ -1,0 +1,58 @@
+From d0a0ccf3fecdb422d3fb7ab89646fe9042f11acd Mon Sep 17 00:00:00 2001
+From: Jay Faulkner <jay@jvf.cc>
+Date: Tue, 3 Feb 2015 17:45:50 -0800
+Subject: nspawn: Allow module loading if CAP_SYS_MODULE is requested
+
+nspawn containers currently block module loading in all cases, with
+no option to disable it. This allows an admin, specifically setting
+capability=CAP_SYS_MODULE or capability=all to load modules.
+
+diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
+index 1e6e7bf..fb67251 100644
+--- a/src/nspawn/nspawn.c
++++ b/src/nspawn/nspawn.c
+@@ -2485,15 +2485,18 @@ static int setup_seccomp(void) {
+         static const int blacklist[] = {
+                 SCMP_SYS(kexec_load),
+                 SCMP_SYS(open_by_handle_at),
+-                SCMP_SYS(init_module),
+-                SCMP_SYS(finit_module),
+-                SCMP_SYS(delete_module),
+                 SCMP_SYS(iopl),
+                 SCMP_SYS(ioperm),
+                 SCMP_SYS(swapon),
+                 SCMP_SYS(swapoff),
+         };
+ 
++        static const int kmod_blacklist[] = {
++                SCMP_SYS(init_module),
++                SCMP_SYS(finit_module),
++                SCMP_SYS(delete_module),
++        };
++
+         scmp_filter_ctx seccomp;
+         unsigned i;
+         int r;
+@@ -2518,6 +2521,20 @@ static int setup_seccomp(void) {
+                 }
+         }
+ 
++        /* If the CAP_SYS_MODULE capability is not requested then
++         * we'll block the kmod syscalls too */
++        if (!(arg_retain & (1ULL << CAP_SYS_MODULE))) {
++                for (i = 0; i < ELEMENTSOF(kmod_blacklist); i++) {
++                        r = seccomp_rule_add(seccomp, SCMP_ACT_ERRNO(EPERM), kmod_blacklist[i], 0);
++                        if (r == -EFAULT)
++                                continue; /* unknown syscall */
++                        if (r < 0) {
++                                log_error_errno(r, "Failed to block syscall: %m");
++                                goto finish;
++                        }
++                }
++        }
++
+         /*
+            Audit is broken in containers, much of the userspace audit
+            hookup will fail if running inside a container. We don't
+-- 
+cgit v0.10.2

--- a/sys-apps/systemd/systemd-218-r4.ebuild
+++ b/sys-apps/systemd/systemd-218-r4.ebuild
@@ -179,6 +179,8 @@ fi
 
 	# https://github.com/coreos/bugs/issues/220
 	epatch "${FILESDIR}"/218-0001-networkd-accept-a-trailing-.-on-the-end-of-domains.patch
+	# https://github.com/coreos/bugs/issues/260
+	epatch "${FILESDIR}"/218-0002-allow-module-loading.patch
 
 	autotools-utils_src_prepare
 }


### PR DESCRIPTION
http://cgit.freedesktop.org/systemd/systemd/commit/?id=d0a0ccf3fecdb422d3fb7ab89646fe9042f11acd

Addresses https://github.com/coreos/bugs/issues/260.