### PR TITLE
systemd: backport patch for DefaultDependencies on transient units

### DIFF
--- a/sys-apps/systemd/files/218-0003-core-open-up-DefaultDependencies-property-for-transi.patch
+++ b/sys-apps/systemd/files/218-0003-core-open-up-DefaultDependencies-property-for-transi.patch
@@ -1,0 +1,53 @@
+From e61fa9feb66c85686a1dd5d54517978ae1032768 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Tue, 3 Feb 2015 19:07:40 +0100
+Subject: [PATCH] core: open up DefaultDependencies= property for transient
+ units
+
+---
+ src/core/dbus-unit.c             | 14 ++++++++++++++
+ src/libsystemd/sd-bus/bus-util.c |  3 +--
+ 2 files changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/src/core/dbus-unit.c b/src/core/dbus-unit.c
+index b968009..6a0fec2 100644
+--- a/src/core/dbus-unit.c
++++ b/src/core/dbus-unit.c
+@@ -862,6 +862,20 @@ static int bus_unit_set_transient_property(
+ 
+                 return 1;
+ 
++        } else if (streq(name, "DefaultDependencies")) {
++                int b;
++
++                r = sd_bus_message_read(message, "b", &b);
++                if (r < 0)
++                        return r;
++
++                if (mode != UNIT_CHECK) {
++                        u->default_dependencies = b;
++                        unit_write_drop_in_format(u, mode, name, "[Unit]\nDefaultDependencies=%s\n", yes_no(b));
++                }
++
++                return 1;
++
+         } else if (streq(name, "Slice") && unit_get_cgroup_context(u)) {
+                 const char *s;
+ 
+diff --git a/src/libsystemd/sd-bus/bus-util.c b/src/libsystemd/sd-bus/bus-util.c
+index 0f1a89c..022d866 100644
+--- a/src/libsystemd/sd-bus/bus-util.c
++++ b/src/libsystemd/sd-bus/bus-util.c
+@@ -1372,8 +1372,7 @@ int bus_append_unit_property_assignment(sd_bus_message *m, const char *assignmen
+ 
+         if (STR_IN_SET(field,
+                        "CPUAccounting", "MemoryAccounting", "BlockIOAccounting",
+-                       "SendSIGHUP", "SendSIGKILL",
+-                       "WakeSystem")) {
++                       "SendSIGHUP", "SendSIGKILL", "WakeSystem", "DefaultDependencies")) {
+ 
+                 r = parse_boolean(eq);
+                 if (r < 0) {
+-- 
+2.1.4
+

--- a/sys-apps/systemd/systemd-218-r5.ebuild
+++ b/sys-apps/systemd/systemd-218-r5.ebuild
@@ -179,8 +179,12 @@ fi
 
 	# https://github.com/coreos/bugs/issues/220
 	epatch "${FILESDIR}"/218-0001-networkd-accept-a-trailing-.-on-the-end-of-domains.patch
+
 	# https://github.com/coreos/bugs/issues/260
 	epatch "${FILESDIR}"/218-0002-allow-module-loading.patch
+
+	# https://github.com/coreos/bugs/issues/186
+	epatch "${FILESDIR}"/218-0003-core-open-up-DefaultDependencies-property-for-transi.patch
 
 	autotools-utils_src_prepare
 }


### PR DESCRIPTION
Part of fixing https://github.com/coreos/bugs/issues/186