### PR TITLE
Load .bashrc.local, if present

### DIFF
--- a/app-shells/bash/files/dot-bashrc
+++ b/app-shells/bash/files/dot-bashrc
@@ -16,3 +16,6 @@ fi
 
 
 # Put your fun stuff here.
+
+# Load local settings, if present
+[[ -f ~/.bashrc.local ]] && . ~/.bashrc.local


### PR DESCRIPTION
.bashrc is presently a symbolic link to the read-only /usr partition, which is a good idea.  However, there is no simple way to customize the login script with things like TERM overrides, aliases, etc.

This patch will source the `.bashrc.local` file, if present.
