### PR TITLE
app-emulation/waagent: correct ebuild

### DIFF
--- a/app-emulation/wa-linux-agent/wa-linux-agent-2.0.11-r2.ebuild
+++ b/app-emulation/wa-linux-agent/wa-linux-agent-2.0.11-r2.ebuild
@@ -10,7 +10,7 @@ EGIT_REPO_URI="git://github.com/Azure/WALinuxAgent"
 EGIT_COMMIT="b3f2619a854455675ae5f2ee14726659e0398af7" # WALinuxAgent-2.0.11
 EGIT_MASTER="2.0"
 
-inherit toolchain-funcs git-2
+inherit eutils toolchain-funcs git-2
 
 DESCRIPTION="Windows Azure Linux Agent"
 HOMEPAGE="https://github.com/Azure/WALinuxAgent"


### PR DESCRIPTION
The SSH patch wasn't actually being applied because the ebuild silently
failed with "epatch: command not found".