### PR TITLE
profiles: enable lzma on systemd

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -39,7 +39,7 @@ net-analyzer/nmap ncat -lua
 app-admin/sudo -sendmail
 
 # avoid pulling in gnutls, disable gentoo-only bits, enable journal upload
-sys-apps/systemd -ssl curl vanilla
+sys-apps/systemd -ssl curl vanilla lzma
 
 # disable kernel config detection and module building
 net-firewall/ipset -modules


### PR DESCRIPTION
This will allow journald to compress the journal. More interestingly, it will give journalctl the ability to read both COMPRESSED-XZ and non-compressed journals. This is useful if you want to read, for example, a Fedora 21 journal from CoreOS.