### PR TITLE
dev-db: use LimitNOFILE and LimitNPROC for etcd

### DIFF
--- a/dev-db/etcd/files/etcd.service
+++ b/dev-db/etcd/files/etcd.service
@@ -6,6 +6,7 @@ User=etcd
 PermissionsStartOnly=true
 Environment=ETCD_DATA_DIR=/var/lib/etcd
 Environment=ETCD_NAME=%m
-ExecStart=/usr/bin/etcd 
+ExecStart=/usr/bin/etcd
 Restart=always
 RestartSec=10s
+LimitNOFILE=40000


### PR DESCRIPTION
Docker and flannel already use these, and we've seen issues where
etcd runs out of file handles.