### PR TITLE
sys-apps/coreutils: dont copy DIR_COLORS into etc

### DIFF
--- a/sys-apps/coreutils/coreutils-8.20-r102.ebuild
+++ b/sys-apps/coreutils/coreutils-8.20-r102.ebuild
@@ -126,9 +126,6 @@ src_install() {
 	emake install DESTDIR="${D}" || die
 	dodoc AUTHORS ChangeLog* NEWS README* THANKS TODO
 
-	insinto /etc
-	newins src/dircolors.hin DIR_COLORS || die
-
 	if [[ ${USERLAND} == "GNU" ]] ; then
 		cd "${D}"/usr/bin
 		dodir /bin

--- a/sys-apps/coreutils/coreutils-8.23-r1.ebuild
+++ b/sys-apps/coreutils/coreutils-8.23-r1.ebuild
@@ -132,9 +132,6 @@ src_test() {
 src_install() {
 	default
 
-	insinto /etc
-	newins src/dircolors.hin DIR_COLORS
-
 	if [[ ${USERLAND} == "GNU" ]] && ! use symlink-usr; then
 		cd "${ED}"/usr/bin
 		dodir /bin


### PR DESCRIPTION
unfortunately, dircolors(1) is still installed in /usr/bin, but this is one less file in /etc.