### PR TITLE
oem-gce: bind-mount /var/run/docker.sock to gcloud container

### DIFF
--- a/coreos-base/oem-gce/files/cloud-config.yml
+++ b/coreos-base/oem-gce/files/cloud-config.yml
@@ -114,6 +114,6 @@ write_files:
     permissions: 0644
     content: |
         #!/bin/sh
-        alias gcloud="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config google/cloud-sdk gcloud"
+        alias gcloud="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config -v /var/run/docker.sock:/var/run/docker.sock google/cloud-sdk gcloud"
         alias gcutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config google/cloud-sdk gcutil"
         alias gsutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config google/cloud-sdk gsutil"


### PR DESCRIPTION
The command `gcloud preview docker` requires access to the host system docker.

I will create a PR at https://github.com/GoogleCloudPlatform/cloud-sdk-docker to add docker to the container.

See https://github.com/GeertJohan/dockerfiles/tree/master/google-cloud-sdk-with-docker for more information.