### PR TITLE
coreos-base/oem-*: clean up OEM cloud-configs

### DIFF
--- a/coreos-base/oem-azure/files/cloud-config.yml
+++ b/coreos-base/oem-azure/files/cloud-config.yml
@@ -2,6 +2,14 @@
 
 coreos:
   units:
+    - name: etcd.service
+      runtime: true
+      drop-ins:
+        - name: 10-oem.conf
+          content: |
+            [Service]
+            Environment=ETCD_PEER_ELECTION_TIMEOUT=1200
+
     - name: waagent.service
       command: start
       runtime: true
@@ -34,10 +42,3 @@ coreos:
     version-id: @@OEM_VERSION_ID@@
     home-url: https://azure.microsoft.com/
     bug-report-url: https://github.com/coreos/bugs/issues
-
-write_files:
-    - path: /run/systemd/system/etcd.service.d/10-oem.conf
-      permissions: 0644
-      content: |
-        [Service]
-        Environment=ETCD_PEER_ELECTION_TIMEOUT=1200

--- a/coreos-base/oem-cloudsigma/files/cloud-config.yml
+++ b/coreos-base/oem-cloudsigma/files/cloud-config.yml
@@ -2,6 +2,14 @@
 
 coreos:
   units:
+    - name: etcd.service
+      runtime: true
+      drop-ins:
+        - name: 10-oem.conf
+          content: |
+            [Service]
+            Environment=ETCD_PEER_ELECTION_TIMEOUT=1200
+
     - name: oem-cloudinit.service
       command: restart
       runtime: yes
@@ -12,16 +20,10 @@ coreos:
         [Service]
         Type=oneshot
         ExecStart=/usr/bin/coreos-cloudinit --oem=cloudsigma
+
   oem:
     id: cloudsigma
     name: CloudSigma
     version-id: @@OEM_VERSION_ID@@
     home-url: https://www.cloudsigma.com/
     bug-report-url: https://github.com/coreos/bugs/issues
-
-write_files:
-  - path: /run/systemd/system/etcd.service.d/10-oem.conf
-    permissions: 0644
-    content: |
-      [Service]
-      Environment=ETCD_PEER_ELECTION_TIMEOUT=1200

--- a/coreos-base/oem-ec2-compat/files/cloud-config.yml
+++ b/coreos-base/oem-ec2-compat/files/cloud-config.yml
@@ -1,30 +1,35 @@
 #cloud-config
 
 coreos:
-    units:
-      - name: user-configdrive.service
-        mask: yes
-      - name: user-configvirtfs.service
-        mask: yes
-      - name: oem-cloudinit.service
-        command: restart
-        runtime: yes
-        content: |
-          [Unit]
-          Description=Cloudinit from EC2-style metadata
+  units:
+    - name: etcd.service
+      runtime: true
+      drop-ins:
+        - name: 10-oem.conf
+          content: |
+            [Service]
+            Environment=ETCD_PEER_ELECTION_TIMEOUT=1200
 
-          [Service]
-          Type=oneshot
-          ExecStart=/usr/bin/coreos-cloudinit --oem=ec2-compat
-    oem:
-      id: @@OEM_ID@@
-      name: @@OEM_NAME@@
-      version-id: @@OEM_VERSION_ID@@
-      home-url: @@OEM_HOME_URL@@
-      bug-report-url: https://github.com/coreos/bugs/issues
-write_files:
-    - path: /run/systemd/system/etcd.service.d/10-oem.conf
-      permissions: 0644
+    - name: user-configdrive.service
+      mask: yes
+
+    - name: user-configvirtfs.service
+      mask: yes
+
+    - name: oem-cloudinit.service
+      command: restart
+      runtime: yes
       content: |
+        [Unit]
+        Description=Cloudinit from EC2-style metadata
+
         [Service]
-        Environment=ETCD_PEER_ELECTION_TIMEOUT=1200
+        Type=oneshot
+        ExecStart=/usr/bin/coreos-cloudinit --oem=ec2-compat
+
+  oem:
+    id: @@OEM_ID@@
+    name: @@OEM_NAME@@
+    version-id: @@OEM_VERSION_ID@@
+    home-url: @@OEM_HOME_URL@@
+    bug-report-url: https://github.com/coreos/bugs/issues

--- a/coreos-base/oem-rackspace/files/cloud-config.yml
+++ b/coreos-base/oem-rackspace/files/cloud-config.yml
@@ -1,42 +1,45 @@
 #cloud-config
 
 coreos:
-    units:
-      - name: nova-agent-auto.service
-        command: restart
-        runtime: yes
-        content: |
-          [Unit]
-          After=dbus.service
-          [Service]
-          Environment=HOME=/root
-          ExecStartPre=/bin/mount -t proc none /usr/share/oem/nova-agent/proc
-          ExecStartPre=/bin/mount -t xenfs none /usr/share/oem/nova-agent/proc/xen
-          ExecStartPre=/bin/mount --bind /dev /usr/share/oem/nova-agent/dev
-          ExecStartPre=/bin/mount --bind /sys /usr/share/oem/nova-agent/sys
-          ExecStart=/usr/bin/chroot /usr/share/oem/nova-agent/ /usr/share/nova-agent/0.0.1.38/sbin/nova-agent -o - -n -l info /usr/share/nova-agent/nova-agent.py
-          ExecStopPost=/bin/umount -f /usr/share/oem/nova-agent/sys
-          ExecStopPost=/bin/umount -f /usr/share/oem/nova-agent/dev
-          ExecStopPost=/bin/umount -f /usr/share/oem/nova-agent/proc/xen
-          ExecStopPost=/bin/umount -f /usr/share/oem/nova-agent/proc
-      - name: nova-agent-watcher.service
-        command: restart
-        runtime: yes
-        content: |
-          [Unit]
-          After=dbus.service
+  units:
+    - name: etcd.service
+      runtime: true
+      drop-ins:
+        - name: 10-oem.conf
+          content: |
+            [Service]
+            Environment=ETCD_PEER_ELECTION_TIMEOUT=1200
 
-          [Service]
-          ExecStart=/usr/share/oem/bin/nova-agent-watcher -watch-dir=/usr/share/oem/nova-agent -scripts-dir=/usr/share/oem/bin/
-    oem:
-      id: rackspace
-      name: Rackspace Cloud Servers
-      version-id: @@OEM_VERSION_ID@@
-      home-url: https://www.rackspace.com/cloud/servers/
-      bug-report-url: https://github.com/coreos/coreos-overlay
-write_files:
-    - path: /run/systemd/system/etcd.service.d/10-oem.conf
-      permissions: 0644
+    - name: nova-agent-auto.service
+      command: restart
+      runtime: yes
       content: |
+        [Unit]
+        After=dbus.service
         [Service]
-        Environment=ETCD_PEER_ELECTION_TIMEOUT=1200
+        Environment=HOME=/root
+        ExecStartPre=/bin/mount -t proc none /usr/share/oem/nova-agent/proc
+        ExecStartPre=/bin/mount -t xenfs none /usr/share/oem/nova-agent/proc/xen
+        ExecStartPre=/bin/mount --bind /dev /usr/share/oem/nova-agent/dev
+        ExecStartPre=/bin/mount --bind /sys /usr/share/oem/nova-agent/sys
+        ExecStart=/usr/bin/chroot /usr/share/oem/nova-agent/ /usr/share/nova-agent/0.0.1.38/sbin/nova-agent -o - -n -l info /usr/share/nova-agent/nova-agent.py
+        ExecStopPost=/bin/umount -f /usr/share/oem/nova-agent/sys
+        ExecStopPost=/bin/umount -f /usr/share/oem/nova-agent/dev
+        ExecStopPost=/bin/umount -f /usr/share/oem/nova-agent/proc/xen
+        ExecStopPost=/bin/umount -f /usr/share/oem/nova-agent/proc
+    - name: nova-agent-watcher.service
+      command: restart
+      runtime: yes
+      content: |
+        [Unit]
+        After=dbus.service
+
+        [Service]
+        ExecStart=/usr/share/oem/bin/nova-agent-watcher -watch-dir=/usr/share/oem/nova-agent -scripts-dir=/usr/share/oem/bin/
+
+  oem:
+    id: rackspace
+    name: Rackspace Cloud Servers
+    version-id: @@OEM_VERSION_ID@@
+    home-url: https://www.rackspace.com/cloud/servers/
+    bug-report-url: https://github.com/coreos/bugs/issues


### PR DESCRIPTION
Use coreos.units instead of write_files for writing the etcd dropins.
Clean up the indentation of the config.