### PR TITLE
profiles: mask cross compiler flags that are masked on target

### DIFF
--- a/profiles/coreos/targets/sdk/package.use.mask
+++ b/profiles/coreos/targets/sdk/package.use.mask
@@ -1,0 +1,3 @@
+# hardened and sanitize are masked for arm64, cross compilers should agree
+cross-aarch64-cros-linux-gnu/gcc hardened sanitize
+cross-aarch64-cros-linux-gnu/glibc hardened


### PR DESCRIPTION
The hardened and sanitizer options are masked on arm64 so the arm64
cross compiler should also not enable them instead of inheriting the
amd64 default to enable them. Fixes building cross gcc.