### PR TITLE
profiles: use curl 7.41 or greater to pull in ipv4/ipv6 connection fixes

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -111,3 +111,7 @@ dev-util/checkbashisms
 
 # Fixes findmnt with overlay and btrfs filesystems
 =sys-apps/util-linux-2.26.1
+
+# fix for https://github.com/coreos/bugs/issues/324
+=net-misc/curl-7.41
+


### PR DESCRIPTION
updates coreos/bugs#324