### PR TITLE
scripts: do not include board binaries in $PATH

### DIFF
--- a/coreos/scripts/config_wrapper
+++ b/coreos/scripts/config_wrapper
@@ -40,11 +40,9 @@ if [[ -z ${CHOST} ]] || [[ -z ${SYSROOT} ]] ; then
   exit 1
 fi
 
-PATH="${SYSROOT}/usr/bin:${PATH}"
-
 # Some wrappers will dynamically figure out where they're being run from,
 # and then output a full path -I/-L path based on that.  So we trim any
 # expanded sysroot paths that might be in the output already to avoid
 # having it be -L${SYSROOT}${SYSROOT}/usr/lib.
 set -o pipefail
-exec ${cfg} "$@" | sed -r "s:(-[IL])(${SYSROOT})?:\1${SYSROOT}:g"
+exec ${SYSROOT}/usr/bin/${cfg} "$@" | sed -r "s:(-[IL])(${SYSROOT})?:\1${SYSROOT}:g"


### PR DESCRIPTION
The wrapper for `foo-config` style scripts updated `$PATH` so it could
call the real script by name instead of full path. However this means
that calls to shell utilities like `sed` may use the board's version
instead of the build host's. This hasn't been a problem in the past
because the board and host happened to be compatible but this may not
always be true.

Alternatively the call to sed in this script could be fixed while path is left as-is. This is what https://github.com/coreos/coreos-overlay/pull/1216 proposed. After a quick review of the config scripts involved it looks like some make calls to cat and sed themselves while none of them derive too much meaning from the script name in $0 so calling by absolute path appears to be the safest.