### PR TITLE
profiles: mask new broken portage

### DIFF
--- a/profiles/coreos/base/package.mask
+++ b/profiles/coreos/base/package.mask
@@ -15,3 +15,6 @@
 # Require our ca-certificates package based directly on Mozilla's
 # certificate store provided in NSS rather than the Gentoo/Debian package.
 >=app-misc/ca-certificates-20000000
+
+# Broken when binpkg location is missing
+=sys-apps/portage-2.2.18


### PR DESCRIPTION
Fails when binhost reports a 404:

    !! Error fetching binhost package info from 'http://builds.developer.core-os.net/sdk/amd64/668.0.0/pkgs/'
    Traceback (most recent call last):
      File "/usr/lib/python-exec/python2.7/emerge", line 50, in <module>
        retval = emerge_main()
      File "/usr/lib64/python2.7/site-packages/_emerge/main.py", line 1154, in emerge_main
        return run_action(emerge_config)
      File "/usr/lib64/python2.7/site-packages/_emerge/actions.py", line 2818, in run_action
        getbinpkgs="--getbinpkg" in emerge_config.opts)
      File "/usr/lib64/python2.7/site-packages/portage/dbapi/bintree.py", line 633, in populate
        self._populate(getbinpkgs)
      File "/usr/lib64/python2.7/site-packages/portage/dbapi/bintree.py", line 1034, in _populate
        _encodings["stdio"], errors="replace"))
    TypeError: coercing to Unicode: need string or buffer, HTTPError found