### PR TITLE
oem-ec2-compat: blacklist xen_fbfront

### DIFF
--- a/coreos-base/oem-ec2-compat/files/grub-ec2.cfg
+++ b/coreos-base/oem-ec2-compat/files/grub-ec2.cfg
@@ -1,0 +1,4 @@
+# CoreOS GRUB settings for EC2
+
+# Blacklist the Xen framebuffer module so it doesn't get loaded at boot
+set linux_append="modprobe.blacklist=xen_fbfront"

--- a/coreos-base/oem-ec2-compat/oem-ec2-compat-0.0.3-r2.ebuild
+++ b/coreos-base/oem-ec2-compat/oem-ec2-compat-0.0.3-r2.ebuild
@@ -43,4 +43,7 @@ src_prepare() {
 src_install() {
 	insinto "/usr/share/oem"
 	doins ${T}/cloud-config.yml
+	if use ec2 ; then
+		newins ${FILESDIR}/grub-ec2.cfg grub.cfg
+	fi
 }


### PR DESCRIPTION
To complete the fix started in 480fb78, we ban xen_fbfront from loading on EC2.
Testing missed a case where this would still happen.

(Testing this fix now.)