### PR TITLE
coreos-overlay: Add arm64 keywords

### DIFF
--- a/app-admin/flannel/flannel-9999.ebuild
+++ b/app-admin/flannel/flannel-9999.ebuild
@@ -4,9 +4,9 @@
 EAPI=4
 
 if [[ "${PV}" == 9999 ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~arm64"
 else
-	KEYWORDS="amd64"
+	KEYWORDS="amd64 arm64"
 fi
 
 inherit systemd

--- a/app-admin/toolbox/toolbox-9999.ebuild
+++ b/app-admin/toolbox/toolbox-9999.ebuild
@@ -7,10 +7,10 @@ CROS_WORKON_LOCALNAME="toolbox"
 CROS_WORKON_REPO="git://github.com"
 
 if [[ "${PV}" == 9999 ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~arm64"
 else
 	CROS_WORKON_COMMIT="fc4fed00e9d178ae2814493d1e6426a4ce74970c"
-	KEYWORDS="amd64"
+	KEYWORDS="amd64 arm64"
 fi
 
 inherit cros-workon

--- a/app-emulation/docker/docker-9999.ebuild
+++ b/app-emulation/docker/docker-9999.ebuild
@@ -17,7 +17,7 @@ if [[ ${PV} == *9999 ]]; then
 else
 	CROS_WORKON_COMMIT="7c8fca2ddb58c8d2c4fb4df31c242886df7dd257" # v1.6.2
 	DOCKER_GITCOMMIT="${CROS_WORKON_COMMIT:0:7}"
-	KEYWORDS="amd64"
+	KEYWORDS="amd64 arm64"
 fi
 
 inherit bash-completion-r1 linux-info multilib systemd udev user cros-workon

--- a/coreos-base/coreos-au-key/coreos-au-key-0.0.2.ebuild
+++ b/coreos-base/coreos-au-key/coreos-au-key-0.0.2.ebuild
@@ -8,7 +8,7 @@ HOMEPAGE="http://github.com/coreos/"
 SRC_URI=""
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 arm x86"
+KEYWORDS="amd64 arm arm64 x86"
 IUSE="cros_host official"
 
 # Do not enable offical and SDK at the same time,

--- a/coreos-base/coreos-dev/coreos-dev-0.1.0.ebuild
+++ b/coreos-base/coreos-dev/coreos-dev-0.1.0.ebuild
@@ -8,7 +8,7 @@ HOMEPAGE="http://coreos.com"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm x86"
+KEYWORDS="amd64 arm arm64 x86"
 IUSE="vm-testing"
 
 # The dependencies here are meant to capture "all the packages

--- a/coreos-base/coreos-experimental/coreos-experimental-0.0.1.ebuild
+++ b/coreos-base/coreos-experimental/coreos-experimental-0.0.1.ebuild
@@ -9,7 +9,7 @@ HOMEPAGE="http://coreos.com"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm x86"
+KEYWORDS="amd64 arm arm64 x86"
 IUSE=""
 
 DEPEND=""

--- a/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -8,10 +8,10 @@ CROS_WORKON_LOCALNAME="init"
 CROS_WORKON_REPO="git://github.com"
 
 if [[ "${PV}" == 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
 	CROS_WORKON_COMMIT="af207c09eff3b8447d457c5e534a0b7ff3aae514"
-	KEYWORDS="amd64 arm x86"
+	KEYWORDS="amd64 arm arm64 x86"
 fi
 
 inherit cros-workon systemd

--- a/coreos-base/coreos/coreos-0.0.1.ebuild
+++ b/coreos-base/coreos/coreos-0.0.1.ebuild
@@ -8,7 +8,7 @@ HOMEPAGE="http://coreos.com"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm x86"
+KEYWORDS="amd64 arm arm64 x86"
 IUSE="etcd_protocols_1 etcd_protocols_2"
 
 

--- a/coreos-base/gmerge/gmerge-9999.ebuild
+++ b/coreos-base/gmerge/gmerge-9999.ebuild
@@ -8,10 +8,10 @@ CROS_WORKON_LOCALNAME="dev"
 CROS_WORKON_LOCALDIR="src/platform"
 
 if [[ "${PV}" == 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
 	CROS_WORKON_COMMIT="66e206c20f22e002bbdaed1982b08b18a9b7f730"
-	KEYWORDS="amd64 arm x86"
+	KEYWORDS="amd64 arm arm64 x86"
 fi
 
 inherit cros-workon

--- a/coreos-base/libchrome/libchrome-180609.ebuild
+++ b/coreos-base/libchrome/libchrome-180609.ebuild
@@ -22,7 +22,7 @@ SRC_URI=""
 
 LICENSE="BSD"
 SLOT="${PV}"
-KEYWORDS="amd64 arm x86"
+KEYWORDS="amd64 arm arm64 x86"
 IUSE="cros_host"
 
 RDEPEND="dev-libs/glib

--- a/coreos-devel/board-packages/board-packages-0.0.1.ebuild
+++ b/coreos-devel/board-packages/board-packages-0.0.1.ebuild
@@ -10,7 +10,7 @@ SRC_URI=""
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64"
+KEYWORDS="amd64 arm64"
 IUSE=""
 
 DEPEND=""

--- a/dev-libs/libdivsufsort/libdivsufsort-2.0.1-r1.ebuild
+++ b/dev-libs/libdivsufsort/libdivsufsort-2.0.1-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="http://libdivsufsort.googlecode.com/files/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 arm x86"
+KEYWORDS="amd64 arm arm64 x86"
 IUSE=""
 
 src_prepare() {

--- a/dev-libs/libdnet/libdnet-1.12.ebuild
+++ b/dev-libs/libdnet/libdnet-1.12.ebuild
@@ -15,7 +15,7 @@ SRC_URI="http://libdnet.googlecode.com/files/${P}.tgz
 
 LICENSE="LGPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 ~mips ppc ppc64 sparc x86 ~x86-fbsd"
 IUSE="ipv6 static-libs test"
 
 #DEPEND="test? ( dev-libs/check )"

--- a/dev-libs/libmspack/libmspack-0.4_alpha.ebuild
+++ b/dev-libs/libmspack/libmspack-0.4_alpha.ebuild
@@ -11,7 +11,7 @@ SRC_URI="http://www.cabextract.org.uk/libmspack/${MY_P}.tar.gz"
 
 LICENSE="LGPL-2"
 SLOT="0"
-KEYWORDS="amd64"
+KEYWORDS="amd64 arm64"
 IUSE="static-libs"
 
 S="${WORKDIR}/${MY_P}"

--- a/dev-util/bsdiff/bsdiff-4.3-r5.ebuild
+++ b/dev-util/bsdiff/bsdiff-4.3-r5.ebuild
@@ -14,7 +14,7 @@ SRC_URI="http://www.daemonology.net/bsdiff/${P}.tar.gz"
 
 SLOT="0"
 LICENSE="BSD-2"
-KEYWORDS="alpha amd64 arm hppa ia64 mips ppc sparc x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 mips ppc sparc x86 ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos"
 
 RDEPEND="app-arch/bzip2
 	dev-libs/libdivsufsort"

--- a/dev-vcs/repo/repo-1.21.ebuild
+++ b/dev-vcs/repo/repo-1.21.ebuild
@@ -13,7 +13,7 @@ SRC_URI=""
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64"
+KEYWORDS="amd64 arm64"
 IUSE=""
 
 DEPEND="${PYTHON_DEPS}"

--- a/sys-apps/rootdev/rootdev-0.0.1-r11.ebuild
+++ b/sys-apps/rootdev/rootdev-0.0.1-r11.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="http://www.chromium.org/"
 SRC_URI=""
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 x86 arm"
+KEYWORDS="amd64 x86 arm arm64"
 IUSE=""
 
 src_compile() {

--- a/sys-apps/rootdev/rootdev-9999.ebuild
+++ b/sys-apps/rootdev/rootdev-9999.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="http://www.chromium.org/"
 SRC_URI=""
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~x86 ~arm"
+KEYWORDS="~amd64 ~x86 ~arm ~arm64"
 IUSE=""
 
 src_compile() {

--- a/sys-apps/seismograph/seismograph-9999.ebuild
+++ b/sys-apps/seismograph/seismograph-9999.ebuild
@@ -7,10 +7,10 @@ CROS_WORKON_REPO="git://github.com"
 AUTOTOOLS_AUTORECONF=1
 
 if [[ "${PV}" == 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
 	CROS_WORKON_COMMIT="8881575d1372b860744afe57b52a153a03c80c6a"
-	KEYWORDS="amd64 arm x86"
+	KEYWORDS="amd64 arm arm64 x86"
 fi
 
 inherit autotools-utils cros-workon

--- a/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -8,10 +8,10 @@ CROS_WORKON_OUTOFTREE_BUILD=1
 CROS_WORKON_REPO="git://github.com"
 
 if [[ "${PV}" == 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
 	CROS_WORKON_COMMIT="2d74829987d0de4c6be2b4b194ed9fdedd50adc9"
-	KEYWORDS="amd64 arm x86"
+	KEYWORDS="amd64 arm arm64 x86"
 fi
 
 inherit cros-workon cros-debug cros-au

--- a/sys-kernel/coreos-firmware/coreos-firmware-99999999.ebuild
+++ b/sys-kernel/coreos-firmware/coreos-firmware-99999999.ebuild
@@ -16,7 +16,7 @@ if [[ ${PV} == 99999999* ]]; then
 	KEYWORDS=""
 else
 	SRC_URI="mirror://gentoo/linux-firmware-${PV}.tar.xz"
-	KEYWORDS="amd64"
+	KEYWORDS="amd64 arm64"
 fi
 
 DESCRIPTION="Linux firmware files"

--- a/sys-libs/nss-usrfiles/nss-usrfiles-9999.ebuild
+++ b/sys-libs/nss-usrfiles/nss-usrfiles-9999.ebuild
@@ -7,10 +7,10 @@ CROS_WORKON_LOCALNAME="nss-altfiles"
 CROS_WORKON_REPO="git://github.com"
 
 if [[ "${PV}" == 9999 ]]; then
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
 	CROS_WORKON_COMMIT="508d986e38c70bd0636740d287d2fe807822fb57" # v2.18.1
-	KEYWORDS="amd64 arm x86"
+	KEYWORDS="amd64 arm arm64 x86"
 fi
 
 inherit cros-workon

--- a/sys-process/ktop/ktop-0.0.1-r17.ebuild
+++ b/sys-process/ktop/ktop-0.0.1-r17.ebuild
@@ -16,7 +16,7 @@ SRC_URI=""
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm x86"
+KEYWORDS="amd64 arm arm64 x86"
 IUSE=""
 
 DEPEND="sys-libs/ncurses"

--- a/sys-process/ktop/ktop-9999.ebuild
+++ b/sys-process/ktop/ktop-9999.ebuild
@@ -14,7 +14,7 @@ SRC_URI=""
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~amd64 ~x86"
 IUSE=""
 
 DEPEND="sys-libs/ncurses"

--- a/virtual/linux-sources/linux-sources-2-r1.ebuild
+++ b/virtual/linux-sources/linux-sources-2-r1.ebuild
@@ -8,7 +8,7 @@ HOMEPAGE="http://www.coreos.com"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm x86"
+KEYWORDS="amd64 arm arm64 x86"
 IUSE="cros_host"
 
 RDEPEND="


### PR DESCRIPTION
Add the arm64 keyword to any ebuilds that need it.