### PR TITLE
replace TMPDIR with DOCKER_TMPDIR

### DIFF
--- a/app-emulation/docker/files/docker.service
+++ b/app-emulation/docker/files/docker.service
@@ -5,7 +5,6 @@ After=docker.socket early-docker.target network.target
 Requires=docker.socket early-docker.target
 
 [Service]
-Environment=TMPDIR=/var/tmp
 EnvironmentFile=-/run/flannel_docker_opts.env
 MountFlags=slave
 LimitNOFILE=1048576


### PR DESCRIPTION
docker 1.6 seems to ignore TMPDIR and puts tmp files into /var/lib/docker/tmp/