### PR TITLE
profile: Update to sys-fs/btrfs-progs-3.17.3

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -76,9 +76,6 @@ dev-util/checkbashisms
 # this version does not segfault when a user isn't in sudoers
 =app-admin/sudo-1.8.10_p2
 
-# Includes fix for checking mount status of loop devices
-=sys-fs/btrfs-progs-3.14_pre20140414
-
 # Current systemd git requires >= 3.10 to build,
 # use 3.13 since Gentoo is starting to stabilize that one:
 # https://bugs.gentoo.org/show_bug.cgi?id=507096
@@ -104,7 +101,7 @@ dev-util/checkbashisms
 =app-arch/lbzip2-2.5
 
 # >=3.16 required by docker 1.4
-=sys-fs/btrfs-progs-3.17.1
+=sys-fs/btrfs-progs-3.17.3
 
 # Fixes findmnt with overlay and btrfs filesystems
 =sys-apps/util-linux-2.26.1


### PR DESCRIPTION
Sync package.accept_keywords with  portage-stable btrfs-progs updates at PR https://github.com/coreos/portage-stable/pull/227

This also removes a mention of =sys-fs/btrfs-progs-3.14_pre20140414, which seems to be a stale entry.

