### PR TITLE
dev-libs/elfutils: Fix compile error with stable

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -113,3 +113,6 @@ dev-util/checkbashisms
 
 # https://bugs.gentoo.org/show_bug.cgi?id=548158
 =sys-apps/gentoo-functions-0.10
+
+# Avoid cross compile error with amd64 stable (elfutils-0.158).
+=dev-libs/elfutils-0.161 ~amd64


### PR DESCRIPTION
The update of the elfutils package for arm64 https://github.com/coreos/portage-stable/pull/232 bumped the amd64 stable to elfutils-0.158 which unfortunatly, has a cross compile bug.  Specify the
unstable ~amd64 (elfutils-0.161) to work around the problem.
