### PR TITLE
coreos-kernel: prepare for using patched kernels

### DIFF
--- a/eclass/coreos-kernel.eclass
+++ b/eclass/coreos-kernel.eclass
@@ -2,6 +2,14 @@
 # Copyright 2012 The Chromium OS Authors.
 # Distributed under the terms of the GNU General Public License v2
 
+# @ECLASS-VARIABLE: COREOS_SOURCE_REVISION
+# @DESCRIPTION:
+# Revision of the source ebuild, e.g. -r1. default is ""
+: ${COREOS_SOURCE_REVISION:=}
+
+COREOS_SOURCE_VERSION="${PV}${COREOS_SOURCE_REVISION}"
+COREOS_SOURCE_NAME="linux-${PV}-coreos${COREOS_SOURCE_REVISION}"
+
 [[ ${EAPI} != "5" ]] && die "Only EAPI=5 is supported"
 
 inherit linux-info toolchain-funcs
@@ -11,14 +19,14 @@ LICENSE="GPL-2 freedist"
 SLOT="0/${PVR}"
 SRC_URI=""
 
-DEPEND="~sys-kernel/coreos-sources-${PV}
+DEPEND="=sys-kernel/coreos-sources-${COREOS_SOURCE_VERSION}
 	sys-kernel/bootengine:="
 
 # Do not analyze or strip installed files
 RESTRICT="binchecks strip"
 
 # Use source installed by coreos-sources
-KERNEL_DIR="${SYSROOT}/usr/src/linux-${PV}"
+KERNEL_DIR="${SYSROOT}/usr/src/${COREOS_SOURCE_NAME}"
 S="${KERNEL_DIR}"
 # Cache kernel build tree under /var
 KBUILD_OUTPUT="${SYSROOT}/var/cache/portage/${CATEGORY}/${PN}"

--- a/sys-kernel/coreos-kernel/coreos-kernel-4.0.7-r1.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-4.0.7-r1.ebuild
@@ -2,6 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
+COREOS_SOURCE_REVISION="-r1"
 inherit coreos-kernel
 
 DESCRIPTION="CoreOS Linux kernel"

--- a/sys-kernel/coreos-sources/coreos-sources-4.0.7-r1.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-4.0.7-r1.ebuild
@@ -2,18 +2,13 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
-K_NOUSENAME="yes"
-K_NOSETEXTRAVERSION="yes"
 ETYPE="sources"
 inherit kernel-2
 detect_version
 
-DESCRIPTION="Full sources for the Linux kernel"
+DESCRIPTION="Full sources for the CoreOS Linux kernel"
 HOMEPAGE="http://www.kernel.org"
 SRC_URI="${KERNEL_URI}"
 
 KEYWORDS="amd64 arm64"
 IUSE=""
-
-# This ebuild is essentially equivalent to the upstream vanilla-sources
-DEPEND="!sys-kernel/vanilla-sources:${SLOT}"


### PR DESCRIPTION
We will be carrying some patches so the version of the source code will
no longer be simply the upstream mainline version. A -coreos or
-coreos-r1 and so forth will be appended. A new variable defining the
source revision (e.g. -r1) has been added so we can continue to bump the
coreos-kernel revision independently of coreos-sources for minor things
like config updates.

Required for https://github.com/coreos/coreos-overlay/pull/1326