### PR TITLE
exoscale network workaround not needed anymore

### DIFF
--- a/coreos-base/oem-exoscale/files/cloud-config.yml
+++ b/coreos-base/oem-exoscale/files/cloud-config.yml
@@ -13,17 +13,6 @@ coreos:
           Type=oneshot
           StandardOutput=journal+console
           ExecStart=/usr/share/oem/bin/exoscale-ssh-key
-      - name: exoscale-network.service
-        command: restart
-        runtime: yes
-        content: |
-          [Unit]
-          Description=Optimize network parameters for performance
-
-          [Service]
-          Type=oneshot
-          StandardOutput=journal+console
-          ExecStart=/usr/share/oem/bin/exoscale-setup-network
       - name: exoscale-cloudinit.service
         command: restart
         runtime: yes

--- a/coreos-base/oem-exoscale/files/exoscale-setup-network
+++ b/coreos-base/oem-exoscale/files/exoscale-setup-network
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-/usr/sbin/ethtool -K eth0 tso off gso off

--- a/coreos-base/oem-exoscale/oem-exoscale-0.0.2.ebuild
+++ b/coreos-base/oem-exoscale/oem-exoscale-0.0.2.ebuild
@@ -30,7 +30,6 @@ src_install() {
 	dobin ${FILESDIR}/exoscale-ssh-key
 	dobin ${FILESDIR}/exoscale-coreos-cloudinit
 	dobin ${FILESDIR}/coreos-setup-environment
-	dobin ${FILESDIR}/exoscale-setup-network
 
 	insinto "/usr/share/oem"
 	doins ${T}/cloud-config.yml


### PR DESCRIPTION
As planned, this workaround is not needed anymore for CoreOS
