### PR TITLE
Fix policycoreutils build

### DIFF
--- a/sys-apps/policycoreutils/policycoreutils-2.4.ebuild
+++ b/sys-apps/policycoreutils/policycoreutils-2.4.ebuild
@@ -88,6 +88,8 @@ src_prepare() {
 		# (so we cannot use an additional package for now).
 		S="${S2}"
 		python_copy_sources
+	else
+		sed s/sepolicy// -i Makefile
 	fi
 }
 


### PR DESCRIPTION
There was still some python leaking into this - skip building sepolicy
to avoid issues with cross-compilation.