### PR TITLE
Remove calls to host tools during selinux policy build

### DIFF
--- a/sec-policy/selinux-base/selinux-base-2.20141203-r5.ebuild
+++ b/sec-policy/selinux-base/selinux-base-2.20141203-r5.ebuild
@@ -123,7 +123,7 @@ src_compile() {
 
 	for i in ${POLICY_TYPES}; do
 		cd "${S}/${i}"
-		emake base || die "${i} compile failed"
+		emake base BINDIR="${ROOT}/usr/bin" || die "${i} compile failed"
 		if use doc; then
 			make html || die
 		fi


### PR DESCRIPTION
SELinux policies were attempting to run the host checkmodule and semodule
commands. The former is easy to fix via pointing them at the build root, the
latter we skip entirely because we don't want to install the policy at this
point - we'll do that during image build.