### PR TITLE
sys-apps/systemd: enable nat use flag for ip masquerading in networkd

### DIFF
--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -33,7 +33,7 @@ HOMEPAGE="http://www.freedesktop.org/wiki/Software/systemd"
 LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0/2"
 IUSE="acl apparmor audit cryptsetup curl doc elfutils gcrypt gnuefi gudev http
-	idn +importd introspection kdbus +kmod +lz4 lzma nat pam policykit python
+	idn +importd introspection kdbus +kmod +lz4 lzma +nat pam policykit python
 	qrcode +seccomp selinux ssl sysv-utils terminal test vanilla xkb"
 
 # Gentoo removed the nls use flag, we'll keep it for now


### PR DESCRIPTION
fix half of coreos/bugs#404