### PR TITLE
ccache and systemd build cleanups

### DIFF
--- a/eclass/coreos-kernel.eclass
+++ b/eclass/coreos-kernel.eclass
@@ -92,8 +92,12 @@ update_bootengine_cpio() {
 }
 
 kmake() {
-	local kernel_arch=$(tc-arch-kernel)
-	emake LDFLAGS="" ARCH="${kernel_arch}" CROSS_COMPILE="${CHOST}-" "$@"
+	local kernel_arch=$(tc-arch-kernel) kernel_cflags=
+	if gcc-specs-pie; then
+		kernel_cflags="-nopie"
+	fi
+	emake ARCH="${kernel_arch}" CROSS_COMPILE="${CHOST}-" \
+		KCFLAGS="${kernel_cflags}" LDFLAGS="" "$@"
 }
 
 # Discard the module signing key, we use new keys for each build.

--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -80,13 +80,17 @@ LINGUAS="en"
 PORTAGE_BZIP2_COMMAND="lbzip2"
 PORTAGE_BUNZIP2_COMMAND="lbunzip2"
 
-# 2.5G seems to be roughly enough to cache a full CoreOS build.
-CCACHE_SIZE="2.5G"
+# Compression allows keeping a much more complete cache, otherwise the
+# kernel alone will eat 1.2GB instead of 455MB. Using /var/tmp/ccache
+# instead of ${ROOT}/var/tmp/ccache enables sharing results across
+# setup_board --force and between different boards of the same arch.
+CCACHE_COMPRESS=1
+CCACHE_DIR="/var/tmp/ccache"
 
 # Always build binary packages, remove old build logs, avoid running as root.
 FEATURES="buildpkg clean-logs compressdebug parallel-install splitdebug
           userfetch userpriv usersandbox ipc-sandbox network-sandbox
-          -merge-sync"
+          ccache -merge-sync"
 
 # No need to restrict access to build directories in dev environments.
 PORTAGE_WORKDIR_MODE="0755"

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -116,3 +116,6 @@ dev-util/checkbashisms
 
 # Avoid cross compile error with amd64 stable (elfutils-0.158).
 =dev-libs/elfutils-0.161 ~amd64
+
+# Avoid locking bugs that bit us in the 3.1.x series.
+=dev-util/ccache-3.2.2

--- a/profiles/coreos/targets/generic/make.defaults
+++ b/profiles/coreos/targets/generic/make.defaults
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 USE="cros-debug acpi usb symlink-usr cryptsetup policykit -pam"
-USE="${USE} -cros_host -expat -cairo -X"
+USE="${USE} -cros_host -expat -cairo -X -man"
 USE="${USE} -acl -cracklib -gpm -python -sha512"
 USE="${USE} -fortran -abiword -perl -cups -poppler-data -nls"
 

--- a/profiles/coreos/targets/sdk/make.defaults
+++ b/profiles/coreos/targets/sdk/make.defaults
@@ -1,4 +1,4 @@
-USE="-pam"
+USE="man -pam"
 
 # Used by some old goo in profiles/coreos/base/profile.bashrc
 # TODO: clean up that old goo

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -36,8 +36,8 @@ IUSE="acl apparmor audit cryptsetup curl doc elfutils gcrypt gnuefi gudev http
 	idn +importd introspection kdbus +kmod +lz4 lzma +nat pam policykit python
 	qrcode +seccomp selinux ssl sysv-utils terminal test vanilla xkb"
 
-# Gentoo removed the nls use flag, we'll keep it for now
-IUSE+=" man nls symlink-usr"
+# CoreOS specific use flags
+IUSE+=" man symlink-usr"
 
 REQUIRED_USE="importd? ( curl gcrypt lzma )"
 
@@ -234,7 +234,6 @@ multilib_src_configure() {
 		$(use_enable lzma xz)
 		$(multilib_native_use_enable man manpages)
 		$(multilib_native_use_enable nat libiptc)
-		$(use_enable nls)
 		$(multilib_native_use_enable pam)
 		$(multilib_native_use_enable policykit polkit)
 		$(multilib_native_use_with python)

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -266,6 +266,11 @@ multilib_src_configure() {
 
 		--with-ntp-servers="0.coreos.pool.ntp.org 1.coreos.pool.ntp.org 2.coreos.pool.ntp.org 3.coreos.pool.ntp.org"
 
+		# The CoreOS epoch, Mon Jul  1 00:00:00 UTC 2013. Used by timesyncd
+		# as a sanity check for the minimum acceptable time. Explicitly set
+		# to avoid using the current build time.
+		--with-time-epoch=1372636800
+
 		# no default name servers
 		--with-dns-servers=
 	)

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -209,8 +209,6 @@ multilib_src_configure() {
 		# no deps
 		--enable-efi
 		--enable-ima
-		# used for stacktraces in log messages, leave off for now
-		--disable-elfutils
 
 		# Optional components/dependencies
 		$(multilib_native_use_enable acl)
@@ -262,7 +260,6 @@ multilib_src_configure() {
 		--with-dbuspolicydir="${EPREFIX}/usr/share/dbus-1/system.d"
 		--with-dbussessionservicedir="${EPREFIX}/usr/share/dbus-1/services"
 		--with-dbussystemservicedir="${EPREFIX}/usr/share/dbus-1/system-services"
-		--with-dbusinterfacedir="${EPREFIX}/usr/share/dbus-1/interfaces"
 
 		--with-ntp-servers="0.coreos.pool.ntp.org 1.coreos.pool.ntp.org 2.coreos.pool.ntp.org 3.coreos.pool.ntp.org"
 

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -37,7 +37,7 @@ IUSE="acl apparmor audit cryptsetup curl doc elfutils gcrypt gnuefi gudev http
 	qrcode +seccomp selinux ssl sysv-utils terminal test vanilla xkb"
 
 # Gentoo removed the nls use flag, we'll keep it for now
-IUSE+=" nls symlink-usr"
+IUSE+=" man nls symlink-usr"
 
 REQUIRED_USE="importd? ( curl gcrypt lzma )"
 
@@ -115,10 +115,10 @@ DEPEND="${COMMON_DEPEND}
 
 # Not required when building from unpatched tarballs, but we build from git.
 DEPEND="${DEPEND}
-	app-text/docbook-xml-dtd:4.2
-	app-text/docbook-xml-dtd:4.5
-	app-text/docbook-xsl-stylesheets
-	dev-libs/libxslt:0
+	man? ( app-text/docbook-xml-dtd:4.2
+		app-text/docbook-xml-dtd:4.5
+		app-text/docbook-xsl-stylesheets
+		dev-libs/libxslt:0 )
 	dev-libs/gobject-introspection
 	>=dev-libs/libgcrypt-1.4.5:0"
 
@@ -232,6 +232,7 @@ multilib_src_configure() {
 		$(multilib_native_use_enable kmod)
 		$(use_enable lz4)
 		$(use_enable lzma xz)
+		$(multilib_native_use_enable man manpages)
 		$(multilib_native_use_enable nat libiptc)
 		$(use_enable nls)
 		$(multilib_native_use_enable pam)
@@ -357,7 +358,7 @@ multilib_src_install_all() {
 			dosym "${ROOTPREFIX-/usr}/bin/systemctl" ${prefix}/sbin/${app}
 		done
 		dosym "${ROOTPREFIX-/usr}/lib/systemd/systemd" ${prefix}/sbin/init
-	else
+	elif use man; then
 		# we just keep sysvinit tools, so no need for the mans
 		rm "${D}"/usr/share/man/man8/{halt,poweroff,reboot,runlevel,shutdown,telinit}.8 \
 			|| die


### PR DESCRIPTION
Kernels are now zillions times happier with ccache. systemd is improved some, the majority of its cpu time is now stuck in lto (a good thing, cuts down on systemd binary sizes a lot) and libtool (ugg, seriously shell is a terrible language to write low level tools in).

Depends on https://github.com/coreos/portage-stable/pull/236