### PR TITLE
profiles: remove unneeded entries for openssl

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -89,13 +89,6 @@ dev-util/checkbashisms
 ~app-emulation/xen-tools-4.4.1
 ~app-emulation/xen-pvgrub-4.4.1
 
-# Security update, Gentoo hasn't finished marking it stable yet.
-# https://www.openssl.org/news/secadv_20150611.txt
-# https://bugs.gentoo.org/show_bug.cgi?id=551832
-=dev-libs/openssl-1.0.1n
-# ABI fix, not stable yet
-=dev-libs/openssl-1.0.1o
-
 # Fixes a few bugs but has not yet been marked stable upstream.
 =app-arch/lbzip2-2.5
 


### PR DESCRIPTION
Depends on https://github.com/coreos/portage-stable/pull/237.