### PR TITLE
profiles: use compiler hash for ccache

### DIFF
--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -85,6 +85,7 @@ PORTAGE_BUNZIP2_COMMAND="lbunzip2"
 # instead of ${ROOT}/var/tmp/ccache enables sharing results across
 # setup_board --force and between different boards of the same arch.
 CCACHE_COMPRESS=1
+CCACHE_COMPILERCHECK=content
 CCACHE_DIR="/var/tmp/ccache"
 
 # Always build binary packages, remove old build logs, avoid running as root.


### PR DESCRIPTION
By default ccache checks the compiler's mtime and size but that gets
thrown off by reinstalls, including from binary packages. The
alternative mode reads the compiler binary itself instead. In theory
that may be slower but in reality both modes are effectively the same
speed. ccache will now work under catalyst