### PR TITLE
coreos-overlay: Use latest vim for cross compile fix

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -109,3 +109,9 @@ dev-util/checkbashisms
 
 # Avoid cross compile error with amd64 stable (elfutils-0.158).
 =dev-libs/elfutils-0.161 ~amd64
+
+# Pickup upstream cross-compile fix
+# https://bugs.gentoo.org/show_bug.cgi?id=473372
+=app-editors/vim-7.4.712
+=app-editors/vim-core-7.4.712
+


### PR DESCRIPTION
Specify vim-7.4.712 and vim-core-7.4.712 in package.accept_keywords
to pickup needed upstream cross-compile fix.

  https://bugs.gentoo.org/show_bug.cgi?id=473372

Fix build errors like these:

  checking for tgetent()... configure: error: NOT FOUND!
  You need to install a terminal library; for example ncurses.

Depends on https://github.com/coreos/portage-stable/pull/241 for vim ebuild updates.