### PR TITLE
profiles: fix path to coreos-overlay

### DIFF
--- a/profiles/coreos/base/profile.bashrc
+++ b/profiles/coreos/base/profile.bashrc
@@ -3,7 +3,7 @@
 CROS_BUILD_BOARD_TREE="${SYSROOT}/build"
 CROS_BUILD_BOARD_BIN="${CROS_BUILD_BOARD_TREE}/bin"
 
-CROS_ADDONS_TREE="/usr/local/portage/coreos/coreos"
+CROS_ADDONS_TREE="/mnt/host/source/src/third_party/coreos-overlay/coreos"
 
 # Are we merging for the board sysroot, or for the cros sdk, or for
 # the target hardware?  Returns a string:


### PR DESCRIPTION
Missed this reference to /usr/local/portage in a recent scripts change:

https://github.com/marineam/coreos-scripts/commit/174a847e362f8a1d05210750eafb6ccb4735f59c

So existing SDKs kept working but newly created SDKs would mysteriously
fail to build some things like cmake and vim. :(