### PR TITLE
rkt: fix grace period variable format

### DIFF
--- a/app-emulation/rkt/files/rkt-gc.service
+++ b/app-emulation/rkt/files/rkt-gc.service
@@ -4,4 +4,4 @@ Description=Garbage Collection for rkt
 [Service]
 Environment=GRACE_PERIOD=24h
 Type=oneshot
-ExecStart=/usr/bin/rkt gc --grace-period=$GRACE_PERIOD
+ExecStart=/usr/bin/rkt gc --grace-period=${GRACE_PERIOD}


### PR DESCRIPTION
systemd requires the ${var} syntax when embedded in words.

Missed in https://github.com/coreos/coreos-overlay/pull/1378