### PR TITLE
ignition: add dependency on systemd-networkd.service

### DIFF
--- a/sys-apps/ignition/files/ignition.target
+++ b/sys-apps/ignition/files/ignition.target
@@ -11,3 +11,6 @@ After=ignition-disks.service
 
 Requires=ignition-files.service
 After=ignition-files.service
+
+Requires=systemd-networkd.service
+After=systemd-networkd.service


### PR DESCRIPTION
This relies on https://github.com/coreos/bootengine/pull/52 introducing systemd-networkd to the initramfs.