### PR TITLE
coreos-overlay: Update ktop for arm64

### DIFF
--- a/sys-process/ktop/files/ktop-arm64-syscall-fixes.diff
+++ b/sys-process/ktop/files/ktop-arm64-syscall-fixes.diff
@@ -1,0 +1,27 @@
+Fix syscalls for arm64
+
+diff --git a/display.c b/display.c
+index a5cb2c2..98278b2 100644
+--- a/display.c
++++ b/display.c
+@@ -61,17 +61,14 @@ Display_call_s Display_call[] = {
+ 	{ "pwrite:", __NR_pwrite64 },
+ 	{ "sync:  ", __NR_sync },
+ 	{ "fsync: ", __NR_fsync },
+-	{ "open:  ", __NR_open },
+ 	{ "close: ", __NR_close },
++	{ "fstat: ", __NR_fstat },
++#if defined(__x86_64__)
++	{ "open:  ", __NR_open },
+ 	{ "creat: ", __NR_creat },
+ 	{ "unlink:", __NR_unlink },
+-#ifdef __x86_64__
+ 	{ "stat:  ", __NR_stat },
+-	{ "fstat: ", __NR_fstat },
+ 	{ "lstat: ", __NR_lstat },
+-#else
+-	{ "stat:  ", __NR_stat64 },
+-	{ "fstat: ", __NR_fstat64 },
+ #endif
+ 	{ NULL, 0 }};
+ 

--- a/sys-process/ktop/ktop-0.0.1-r18.ebuild
+++ b/sys-process/ktop/ktop-0.0.1-r18.ebuild
@@ -21,6 +21,10 @@ IUSE=""
 
 DEPEND="sys-libs/ncurses"
 
+src_prepare() {
+	epatch "${FILESDIR}"/ktop-arm64-syscall-fixes.diff
+}
+
 src_compile() {
 	tc-export CC
 	emake || die

--- a/sys-process/ktop/ktop-0.0.1-r18.ebuild
+++ b/sys-process/ktop/ktop-0.0.1-r18.ebuild
@@ -5,7 +5,7 @@
 #
 
 EAPI=2
-CROS_WORKON_COMMIT="70c5dec58e1f2d52cb45edd95f353c0183246def"
+CROS_WORKON_COMMIT="52d09bd25a02b3866aba1bb492f36a2d851d6472"
 CROS_WORKON_TREE="df952e3d5bb2f168ccde7a5a1e8684e9b87a078e"
 CROS_WORKON_PROJECT="chromiumos/third_party/ktop"
 inherit toolchain-funcs cros-workon


### PR DESCRIPTION
Sync with latest and add arm64 build fix.