### PR TITLE
coreos/config: Remove outdated vim fix

### DIFF
--- a/coreos/config/env/app-editors/vim
+++ b/coreos/config/env/app-editors/vim
@@ -1,4 +1,0 @@
-# automatic terminal library selection doesn't work when cross-compiling
-# Gentoo bug: https://bugs.gentoo.org/show_bug.cgi?id=473372
-# Reportedly fixed in app-editors/vim-7.4.430 but we haven't updated yet.
-EXTRA_ECONF="--with-tlib=ncurses"


### PR DESCRIPTION
Commit 5c4e74c68c3262ee35bd039d94b0237df7381888 (profiles: Use latest vim for
cross compile fix) updated vim to vim-7.4.712, which outdates this local fix.
