### PR TITLE
sys-fs/xfsprogs: Add Missing patch file

### DIFF
--- a/sys-fs/xfsprogs/files/xfsprogs-3.1.11-sharedlibs.patch
+++ b/sys-fs/xfsprogs/files/xfsprogs-3.1.11-sharedlibs.patch
@@ -1,0 +1,106 @@
+use libtool to do all installing.  do not use the manual file install as
+that'll copy files directly from the .libs/ subdir which might have rpaths
+that we do not want.
+
+--- a/libdisk/Makefile
++++ b/libdisk/Makefile
+@@ -25,6 +25,7 @@
+ install: default
+ 
+ install-dev: default
++	$(INSTALL_LTLIB_DEV)
+ 
+ install-qa: install-dev
+ 
+--- a/libhandle/Makefile
++++ b/libhandle/Makefile
+@@ -20,7 +20,6 @@
+ include $(BUILDRULES)
+ 
+ install: default
+-	$(INSTALL_LTLIB)
+ 
+ install-dev: default
+ 	$(INSTALL_LTLIB_DEV)
+--- a/libxcmd/Makefile
++++ b/libxcmd/Makefile
+@@ -32,6 +32,11 @@
+ 
+ include $(BUILDRULES)
+ 
+-install install-dev install-qa: default
++install: default
++
++install-dev: default
++	$(INSTALL_LTLIB_DEV)
++
++install-qa: default
+ 
+ -include .dep
+--- a/libxfs/Makefile
++++ b/libxfs/Makefile
+@@ -41,5 +41,6 @@
+ install: default
+ 
+ install-dev: default
++	$(INSTALL_LTLIB_DEV)
+ 
+ install-qa: default
+--- a/libxlog/Makefile
++++ b/libxlog/Makefile
+@@ -12,6 +12,8 @@
+ 
+ CFILES = xfs_log_recover.c util.c
+ 
++LTLIBS = $(LIBUUID) $(LIBXFS)
++
+ # don't want to link xfs_repair with a debug libxlog.
+ DEBUG = -DNDEBUG
+ 
+@@ -19,6 +21,11 @@
+ 
+ include $(BUILDRULES)
+ 
+-install install-dev install-qa: default
++install: default
++
++install-dev: default
++	$(INSTALL_LTLIB_DEV)
++
++install-qa: default
+ 
+ -include .dep
+--- a/Makefile
++++ b/Makefile
+@@ -66,6 +66,8 @@
+ mkfs: libxfs
+ quota: libxcmd
+ repair: libxfs libxlog
++libxlog: libxfs
++libxlog-install-dev: libxfs-install-dev
+ 
+ ifneq ($(ENABLE_BLKID), yes)
+ mkfs: libdisk
+--- a/include/buildmacros
++++ b/include/buildmacros
+@@ -71,17 +71,9 @@
+ # /usr/lib.
+ ifeq ($(ENABLE_SHARED),yes)
+ INSTALL_LTLIB_DEV = \
+-	cd $(TOPDIR)/$(LIBNAME)/.libs; \
+-	../$(INSTALL) -m 755 -d $(PKG_LIB_DIR); \
+-	../$(INSTALL) -m 644 -T old_lib $(LIBNAME).lai $(PKG_LIB_DIR); \
+-	../$(INSTALL) -m 644 $(LIBNAME).lai $(PKG_LIB_DIR)/$(LIBNAME).la ; \
+-	../$(INSTALL) -m 755 -d $(PKG_ROOT_LIB_DIR); \
+-	../$(INSTALL) -T so_base $(LIBNAME).lai $(PKG_ROOT_LIB_DIR); \
+-	if test "x$(PKG_LIB_DIR)" != "x$(PKG_ROOT_LIB_DIR)" ; then \
+-	../$(INSTALL) -S $(PKG_LIB_DIR)/$(LIBNAME).a $(PKG_ROOT_LIB_DIR)/$(LIBNAME).a; \
+-	../$(INSTALL) -S $(PKG_LIB_DIR)/$(LIBNAME).la $(PKG_ROOT_LIB_DIR)/$(LIBNAME).la; \
+-	../$(INSTALL) -S $(PKG_ROOT_LIB_DIR)/$(LIBNAME).so $(PKG_LIB_DIR)/$(LIBNAME).so; \
+-	fi
++	set -e; cd $(TOPDIR)/$(LIBNAME); \
++	$(INSTALL) -m 755 -d $(PKG_LIB_DIR); \
++	env -uDIST_ROOT $(LTINSTALL) $(TOPDIR)/$(LIBNAME)/$(LIBNAME).la $(DIST_ROOT)$(PKG_LIB_DIR)/$(LIBNAME).la
+ else
+ INSTALL_LTLIB_DEV = $(INSTALL_LTLIB_STATIC)
+ endif


### PR DESCRIPTION
Commit dda187651d4c10687fadb27eba27e89d38c26b65 (sys-fs/xfsprogs: Move
from portage-stable) did not include a patch needed for xfsprogs-3.2.1.

Fixes build errore like these:

  Cannot find $EPATCH_SOURCE!
    sys-fs/xfsprogs/files/xfsprogs-3.1.11-sharedlibs.patch

