### PR TITLE
coreos-overlay Enable qemu user mode emulation

### DIFF
--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -102,3 +102,6 @@ DONT_MOUNT_BOOT=1
 
 # Both x86_64 and i386 targets are required for grub testing
 QEMU_SOFTMMU_TARGETS="x86_64 i386 aarch64"
+
+# For cross build support.
+QEMU_USER_TARGETS="aarch64"


### PR DESCRIPTION
Enable building arm64 qemu user mode emulation (qemu-aarch64) in
the SDK to allow for running target utilities like ldconfig during
the image build stage.