### PR TITLE
Revert "profiles: tell ccache to rewrite paths relative to $S"

### DIFF
--- a/profiles/coreos/base/profile.bashrc
+++ b/profiles/coreos/base/profile.bashrc
@@ -99,10 +99,3 @@ SYSROOT_WRAPPERS_BIN="/usr/lib/sysroot-wrappers/bin"
 if [[ "$PATH" != *"$SYSROOT_WRAPPERS_BIN"* ]]; then
     export PATH="$SYSROOT_WRAPPERS_BIN:$PATH"
 fi
-
-# Improve the chance that ccache is valid across versions by making all
-# paths under $S relative to $S, avoiding encoding the package version
-# contained in the path into __FILE__ expansions and debug info.
-if [[ -z "${CCACHE_BASEDIR}" ]] && [[ -d "${S}" ]]; then
-    export CCACHE_BASEDIR="${S}"
-fi


### PR DESCRIPTION
This reverts commit 8259b77fc8eba8cfda54da565882283953bfd61a.

Somehow this is breaking the qemu build. Unknown why yet.