### PR TITLE
sys-apps/ignition: move network depdencies to ignition-disks.service

### DIFF
--- a/sys-apps/ignition/files/ignition-disks.service
+++ b/sys-apps/ignition/files/ignition-disks.service
@@ -8,6 +8,14 @@ Before=local-fs-pre.target
 Requires=mnt-oem.mount
 After=mnt-oem.mount
 
+# setup networking
+Wants=initrd-systemd-networkd.service
+After=initrd-systemd-networkd.service
+
+# generate resolv.conf
+Wants=initrd-systemd-resolved.service
+After=initrd-systemd-resolved.service
+
 [Service]
 Type=oneshot
 TimeoutStartSec=30s

--- a/sys-apps/ignition/files/ignition-files.service
+++ b/sys-apps/ignition/files/ignition-files.service
@@ -9,6 +9,14 @@ After=initrd-root-fs.target
 Requires=mnt-oem.mount
 After=mnt-oem.mount
 
+# setup networking
+Wants=initrd-systemd-networkd.service
+After=initrd-systemd-networkd.service
+
+# generate resolv.conf
+Wants=initrd-systemd-resolved.service
+After=initrd-systemd-resolved.service
+
 [Service]
 Type=oneshot
 TimeoutStartSec=30s

--- a/sys-apps/ignition/files/ignition.target
+++ b/sys-apps/ignition/files/ignition.target
@@ -10,11 +10,3 @@ After=ignition-disks.service
 
 Requires=ignition-files.service
 After=ignition-files.service
-
-# setup networking
-Requires=initrd-systemd-networkd.service
-After=initrd-systemd-networkd.service
-
-# generate resolv.conf
-Requires=initrd-systemd-resolved.service
-After=initrd-systemd-resolved.service


### PR DESCRIPTION
Explicitly order ignition-disks after the network units, and switch
from Requires to Wants in so ignition can still function without them.