### PR TITLE
Don't install /sbin/selinuxenabled

### DIFF
--- a/profiles/coreos/targets/generic/make.defaults
+++ b/profiles/coreos/targets/generic/make.defaults
@@ -42,3 +42,8 @@ INSTALL_MASK="${INSTALL_MASK}
   /usr/lib*/libustr-debug*
   /usr/share/ustr-*
 "
+
+# Remove selinuxenabled because it triggers breakage in Ansible
+INSTALL_MASK="${INSTALL_MASK}
+  /usr/sbin/selinuxenabled
+"


### PR DESCRIPTION
We don't use this for anything, but Ansible won't run if it's present and
the selinux python bindings aren't.

Fixes https://github.com/coreos/bugs/issues/449