### PR TITLE
sys-apps/ignition: ensure ignition-disks runs after disk-uuid

### DIFF
--- a/sys-apps/ignition/files/ignition-disks.service
+++ b/sys-apps/ignition/files/ignition-disks.service
@@ -16,6 +16,9 @@ After=initrd-systemd-networkd.service
 Wants=initrd-systemd-resolved.service
 After=initrd-systemd-resolved.service
 
+# prevent racing with sgdisk and its subsequent udev activity
+After=disk-uuid.service
+
 [Service]
 Type=oneshot
 TimeoutStartSec=30s


### PR DESCRIPTION
There's potential for racing with sgdisk or its generated udev events
which may also open the device if we get scheduled simultaneously.  This
is problematic since ignition-disks may also do partitioning and
formatting of the same devices.