### PR TITLE
coreos-kernel: re-enable ccache path rewriting for kernel builds

### DIFF
--- a/eclass/coreos-kernel.eclass
+++ b/eclass/coreos-kernel.eclass
@@ -93,6 +93,8 @@ kmake() {
 	if gcc-specs-pie; then
 		kernel_cflags="-nopie -fstack-check=no"
 	fi
+	# this can be removed once it is exported globally again
+	export CCACHE_BASEDIR="${S}"
 	emake \
 		ARCH="${kernel_arch}" \
 		CROSS_COMPILE="${CHOST}-" \


### PR DESCRIPTION
The current kernel build process expects ccache to be effective but
since setting CCACHE_BASEDIR globally was reverted in 35d8b34a builds
have been uncached any time the source revision changes.

Until it is safe to set CCACHE_BASEDIR globally again we should at least
make use of it for kernel builds.