### PR TITLE
Add missing package metadata.xml

### DIFF
--- a/app-admin/flannel/metadata.xml
+++ b/app-admin/flannel/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/app-admin/fleet/metadata.xml
+++ b/app-admin/fleet/metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer>
+    <email>alunduil@gentoo.org</email>
+    <name>Alex Brandt</name>
+  </maintainer>
+  <maintainer>
+    <email>code@stefanjunker.de</email>
+    <name>Stefan Junker</name>
+  </maintainer>
+  <longdescription lang="en">
+	</longdescription>
+  <upstream>
+    <remote-id type="github">coreos/fleet</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/app-admin/kubelet/metadata.xml
+++ b/app-admin/kubelet/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/app-admin/locksmith/metadata.xml
+++ b/app-admin/locksmith/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/app-admin/mayday/metadata.xml
+++ b/app-admin/mayday/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/app-admin/sdnotify-proxy/metadata.xml
+++ b/app-admin/sdnotify-proxy/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/app-admin/toolbox/metadata.xml
+++ b/app-admin/toolbox/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/app-admin/updateservicectl/metadata.xml
+++ b/app-admin/updateservicectl/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/app-crypt/efitools/metadata.xml
+++ b/app-crypt/efitools/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+<maintainer>
+ <email>gregkh@gentoo.org</email>
+ <description>do whatever</description>
+</maintainer>
+</pkgmetadata>

--- a/app-emulation/actool/metadata.xml
+++ b/app-emulation/actool/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/app-emulation/docker/metadata.xml
+++ b/app-emulation/docker/metadata.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<longdescription>
+		Docker is an open-source project to easily create lightweight,
+		portable, self-sufficient containers from any application. The same
+		container that a developer builds and tests on a laptop can run at
+		scale, in production, on VMs, bare metal, OpenStack clusters, public
+		clouds and more.
+	</longdescription>
+	<herd>proxy-maintainers</herd>
+	<maintainer status="active">
+		<email>admwiggin@gmail.com</email>
+		<name>Tianon</name>
+	</maintainer>
+	<maintainer>
+		<email>xarthisius@gentoo.org</email>
+		<name>Kacper Kowalik</name>
+	</maintainer>
+	<maintainer>
+		<email>alunduil@gentoo.org</email>
+		<name>Alex Brandt</name>
+	</maintainer>
+	<maintainer>
+		<email>williamh@gentoo.org</email>
+		<name>William Hubbs</name>
+	</maintainer>
+	<use>
+		<flag name="aufs">
+			Enables dependencies for the "aufs" graph driver, including
+			necessary kernel flags.
+		</flag>
+		<flag name="apparmor">
+			Enable AppArmor support.
+		</flag>
+		<flag name="btrfs">
+			Enables dependencies for the "btrfs" graph driver, including
+			necessary kernel flags.
+		</flag>
+		<flag name="contrib">
+			Install additional contrib scripts and components.
+		</flag>
+		<flag name="device-mapper">
+			Enables dependencies for the "devicemapper" graph driver, including
+			necessary kernel flags.
+		</flag>
+		<flag name="experimental">
+			Enable features labelled by upstream to be of "experimental"
+			quality and not yet ready for general consumption.
+		</flag>
+		<flag name="overlay">
+			Enables dependencies for the "overlay" graph driver, including
+			necessary kernel flags.
+		</flag>
+		<flag name="lxc">
+			Enables dependencies for the "lxc" execution driver.
+		</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">docker/docker</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/app-emulation/google-compute-daemon/metadata.xml
+++ b/app-emulation/google-compute-daemon/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/app-emulation/google-startup-scripts/metadata.xml
+++ b/app-emulation/google-startup-scripts/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/app-emulation/nova-agent/metadata.xml
+++ b/app-emulation/nova-agent/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/app-emulation/open-vm-tools/metadata.xml
+++ b/app-emulation/open-vm-tools/metadata.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>vmware</herd>
+	<maintainer>
+		<email>floppym@gentoo.org</email>
+		<name>Mike Gilbert</name>
+	</maintainer>
+	<longdescription>
+		The Open Virtual Machine Tools (open-vm-tools) are the open source
+		implementation of VMware Tools. They are a set of guest operating system
+		virtualization components that enhance performance and user experience
+		of virtual machines.
+	</longdescription>
+	<use>
+		<flag name="doc">Generate API documentation</flag>
+		<flag name="fuse">Build vmblock-fuse in favor of FUSE based blocking mechanism for DnD</flag>
+		<flag name="grabbitmqproxy">Enable grabbitmqproxy</flag>
+		<flag name="pic">Force shared libraries to be built as PIC</flag>
+		<flag name="vgauth">Enable vgauth</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">vmware/open-vm-tools</remote-id>
+		<remote-id type="sourceforge">open-vm-tools</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/app-emulation/open-vmdk/metadata.xml
+++ b/app-emulation/open-vmdk/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/app-emulation/wa-linux-agent/metadata.xml
+++ b/app-emulation/wa-linux-agent/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/app-emulation/xenserver-pv-version/metadata.xml
+++ b/app-emulation/xenserver-pv-version/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/app-emulation/xenstore/metadata.xml
+++ b/app-emulation/xenstore/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/app-misc/ca-certificates/metadata.xml
+++ b/app-misc/ca-certificates/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+<herd>base-system</herd>
+<use>
+  <flag name='cacert'>
+    Include root certs from CAcert (http://www.cacert.org/) and
+    Software in the Public Interest (http://www.spi-inc.org/)
+  </flag>
+</use>
+</pkgmetadata>

--- a/app-portage/eclass-manpages/metadata.xml
+++ b/app-portage/eclass-manpages/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>tools-portage</herd>
+	<maintainer>
+		<email>vapier@gentoo.org</email>
+	</maintainer>
+</pkgmetadata>

--- a/coreos-base/coreos-au-key/metadata.xml
+++ b/coreos-base/coreos-au-key/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/coreos-cloudinit/metadata.xml
+++ b/coreos-base/coreos-cloudinit/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/coreos-dev/metadata.xml
+++ b/coreos-base/coreos-dev/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/coreos-experimental/metadata.xml
+++ b/coreos-base/coreos-experimental/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/coreos-init/metadata.xml
+++ b/coreos-base/coreos-init/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/coreos-metadata/metadata.xml
+++ b/coreos-base/coreos-metadata/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/coreos-sb-keys/metadata.xml
+++ b/coreos-base/coreos-sb-keys/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/coretest/metadata.xml
+++ b/coreos-base/coretest/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/cros-devutils/metadata.xml
+++ b/coreos-base/cros-devutils/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/cros-testutils/metadata.xml
+++ b/coreos-base/cros-testutils/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/gmerge/metadata.xml
+++ b/coreos-base/gmerge/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/hard-host-depends/metadata.xml
+++ b/coreos-base/hard-host-depends/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/libchrome/metadata.xml
+++ b/coreos-base/libchrome/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/nova-agent-watcher/metadata.xml
+++ b/coreos-base/nova-agent-watcher/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-azure/metadata.xml
+++ b/coreos-base/oem-azure/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-cloudsigma/metadata.xml
+++ b/coreos-base/oem-cloudsigma/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-cloudstack/metadata.xml
+++ b/coreos-base/oem-cloudstack/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-digitalocean/metadata.xml
+++ b/coreos-base/oem-digitalocean/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-ec2-compat/metadata.xml
+++ b/coreos-base/oem-ec2-compat/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-exoscale/metadata.xml
+++ b/coreos-base/oem-exoscale/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-gce/metadata.xml
+++ b/coreos-base/oem-gce/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-hyperv/metadata.xml
+++ b/coreos-base/oem-hyperv/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-niftycloud/metadata.xml
+++ b/coreos-base/oem-niftycloud/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-packet/metadata.xml
+++ b/coreos-base/oem-packet/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-rackspace-onmetal/metadata.xml
+++ b/coreos-base/oem-rackspace-onmetal/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-rackspace/metadata.xml
+++ b/coreos-base/oem-rackspace/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-vagrant-key/metadata.xml
+++ b/coreos-base/oem-vagrant-key/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-vagrant/metadata.xml
+++ b/coreos-base/oem-vagrant/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-vmware/metadata.xml
+++ b/coreos-base/oem-vmware/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-xendom0/metadata.xml
+++ b/coreos-base/oem-xendom0/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/protofiles/metadata.xml
+++ b/coreos-base/protofiles/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/update_engine/metadata.xml
+++ b/coreos-base/update_engine/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-devel/board-packages/metadata.xml
+++ b/coreos-devel/board-packages/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-devel/mantle/metadata.xml
+++ b/coreos-devel/mantle/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-devel/sdk-depends/metadata.xml
+++ b/coreos-devel/sdk-depends/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/dev-db/etcd/metadata.xml
+++ b/dev-db/etcd/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/dev-db/etcdctl/metadata.xml
+++ b/dev-db/etcdctl/metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <upstream>
+    <bugs-to>https://github.com/coreos/etcdctl/issues</bugs-to>
+    <changelog>https://github.com/coreos/etcdctl/commits/master</changelog>
+    <doc>https://github.com/coreos/etcdctl/blob/master/README.md</doc>
+    <remote-id type="github">coreos/etcdctl</remote-id>
+  </upstream>
+  <maintainer>
+    <email>zmedico@gentoo.org</email>
+  </maintainer>
+</pkgmetadata>

--- a/dev-lang/go/metadata.xml
+++ b/dev-lang/go/metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer>
+		<email>williamh@gentoo.org</email>
+		<name>William Hubbs</name>
+	</maintainer>
+	<longdescription lang="en">
+		Go is a new systems programming language developped at google by
+		Rob Pike. It has garbage collection, coroutines, communication
+		channels and a clean syntax.  
+	</longdescription>
+</pkgmetadata>

--- a/dev-lang/python-oem/metadata.xml
+++ b/dev-lang/python-oem/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/dev-lang/spidermonkey/metadata.xml
+++ b/dev-lang/spidermonkey/metadata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>mozilla</herd>
+	<longdescription lang="en">
+		Stand-alone JavaScript C library
+	</longdescription>
+	<use>
+		<flag name='debug'>Enable assertions to allow for easier debugging of programs that link to spidermonkey -- note this will often crash software on regular end-user systems</flag>
+		<flag name='threadsafe'>Build a threadsafe version of spidermonkey</flag>
+		<flag name='system-icu'>Use the system-wide <pkg>dev-libs/icu</pkg> instead of bundled -- note, only takes effect when icu flag is enabled</flag>
+	</use>
+</pkgmetadata>
+

--- a/dev-libs/libdnet/metadata.xml
+++ b/dev-libs/libdnet/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>netmon</herd>
+	<upstream>
+		<remote-id type="google-code">libdnet</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/dev-libs/libmspack/metadata.xml
+++ b/dev-libs/libmspack/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/dev-python/gdata/metadata.xml
+++ b/dev-python/gdata/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>python</herd>
+	<upstream>
+		<remote-id type="google-code">gdata-python-client</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/dev-util/bsdiff/metadata.xml
+++ b/dev-util/bsdiff/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer>
+		<email>pinkbyte@gentoo.org</email>
+		<name>Sergey Popov</name>
+	</maintainer>
+</pkgmetadata>

--- a/dev-util/ccache/metadata.xml
+++ b/dev-util/ccache/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <herd>toolchain</herd>
+  <maintainer>
+    <email>robbat2@gentoo.org</email>
+  </maintainer>
+  <longdescription lang="en">
+		ccache acts as a caching pre-processor to C/C++ compilers, improving
+		compilation time when recompiling previously compiled source.
+	</longdescription>
+</pkgmetadata>

--- a/dev-util/crosutils/metadata.xml
+++ b/dev-util/crosutils/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/dev-util/go-bindata/metadata.xml
+++ b/dev-util/go-bindata/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/dev-util/lcov/metadata.xml
+++ b/dev-util/lcov/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>dev-tools</herd>
+	<upstream>
+		<remote-id type="sourceforge">ltp</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/dev-vcs/repo/metadata.xml
+++ b/dev-vcs/repo/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/net-fs/nfs-utils/metadata.xml
+++ b/net-fs/nfs-utils/metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <herd>net-fs</herd>
+  <longdescription>NFS client and server daemons</longdescription>
+  <use>
+    <flag name="libmount">Link mount.nfs with libmount</flag>
+    <flag name="nfsdcld">Enable nfsdcld NFSv4 clientid tracking daemon</flag>
+    <flag name="nfsidmap">Enable support for newer nfsidmap helper</flag>
+    <flag name="nfsv4">Enable support for NFSv4</flag>
+    <flag name="nfsv41">Enable support for NFSv4.1</flag>
+    <flag name="uuid">Support UUID lookups in rpc.mountd</flag>
+  </use>
+  <upstream>
+    <remote-id type="sourceforge">nfs</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/net-libs/libnfsidmap/metadata.xml
+++ b/net-libs/libnfsidmap/metadata.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+<herd>net-fs</herd>
+</pkgmetadata>

--- a/net-libs/libtirpc/metadata.xml
+++ b/net-libs/libtirpc/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>net-fs</herd>
+	<upstream>
+		<remote-id type="sourceforge">libtirpc</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/net-misc/ntp/metadata.xml
+++ b/net-misc/ntp/metadata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <herd>base-system</herd>
+  <longdescription>
+NTP is a protocol designed to synchronize the clocks of computers over a network. NTP 
+version 3 is an internet draft standard, formalized in RFC 1305. NTP version 4 is a 
+significant revision of the NTP standard, and is the current development version, but 
+has not been formalized in an RFC. Simple NTP (SNTP) version 4 is described in RFC 
+2030.
+</longdescription>
+  <use>
+    <flag name="openntpd">Allow ntp to be installed alongside openntpd</flag>
+    <flag name="parse-clocks">Add support for PARSE clocks</flag>
+    <flag name="samba">Provide support for Samba's signing daemon (needed for Active Directory domain controllers)</flag>
+  </use>
+  <upstream>
+    <remote-id type="cpe">cpe:/a:ntp:ntp</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/sys-apps/baselayout/metadata.xml
+++ b/sys-apps/baselayout/metadata.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+<herd>base-system</herd>
+</pkgmetadata>

--- a/sys-apps/coreutils/metadata.xml
+++ b/sys-apps/coreutils/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+<herd>base-system</herd>
+<upstream>
+  <remote-id type="cpe">cpe:/a:gnu:coreutils</remote-id>
+</upstream>
+<use>
+  <flag name='multicall'>Build all tools into a single `coreutils` program akin to busybox to save space</flag>
+</use>
+</pkgmetadata>

--- a/sys-apps/efunctions/metadata.xml
+++ b/sys-apps/efunctions/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/sys-apps/ignition/metadata.xml
+++ b/sys-apps/ignition/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/sys-apps/iotools/metadata.xml
+++ b/sys-apps/iotools/metadata.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+<maintainer>
+ <email>vapier@gentoo.org</email>
+</maintainer>
+<use>
+ <flag name='make-symlinks'>Generate sub-command symlinks to iotools -- note that a lot are simple like "xor"</flag>
+</use>
+</pkgmetadata>

--- a/sys-apps/iproute2/metadata.xml
+++ b/sys-apps/iproute2/metadata.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+<herd>base-system</herd>
+<use>
+	<flag name='berkdb'>build programs that use berkdb (just arpd)</flag>
+	<flag name='iptables'>include support for iptables filtering</flag>
+	<flag name='minimal'>only install ip and tc programs</flag>
+</use>
+</pkgmetadata>

--- a/sys-apps/keyutils/metadata.xml
+++ b/sys-apps/keyutils/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <herd>base-system</herd>
+  <maintainer>
+    <email>robbat2@gentoo.org</email>
+  </maintainer>
+</pkgmetadata>

--- a/sys-apps/portage/metadata.xml
+++ b/sys-apps/portage/metadata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <upstream>
+    <bugs-to>mailto:dev-portage@gentoo.org</bugs-to>
+    <changelog>https://gitweb.gentoo.org/proj/portage.git/plain/RELEASE-NOTES</changelog>
+    <doc>https://wiki.gentoo.org/wiki/Handbook:AMD64/Working/Portage</doc>
+  </upstream>
+  <maintainer>
+    <email>dev-portage@gentoo.org</email>
+  </maintainer>
+  <use>
+    <flag name="epydoc">Build html API documentation with epydoc.</flag>
+    <flag name="ipc">Use inter-process communication between portage and running ebuilds.</flag>
+    <flag name="pypy2_0">Use pypy-c2.0 as Python interpreter.</flag>
+    <flag name="python2">Use python2 as Python interpreter.</flag>
+    <flag name="python3">Use python3 as Python interpreter.</flag>
+    <flag name="xattr">Preserve extended attributes (filesystem-stored metadata) when installing files. Usually only required for hardened systems.</flag>
+  </use>
+</pkgmetadata>

--- a/sys-apps/rootdev/metadata.xml
+++ b/sys-apps/rootdev/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/sys-apps/seismograph/metadata.xml
+++ b/sys-apps/seismograph/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/sys-apps/shadow/metadata.xml
+++ b/sys-apps/shadow/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+<herd>base-system</herd>
+<herd>pam</herd> <!-- only for USE=pam -->
+<use>
+ <flag name='audit'>Enable support for <pkg>sys-process/audit</pkg></flag>
+</use>
+<upstream>
+ <remote-id type="cpe">cpe:/a:debian:shadow</remote-id>
+</upstream>
+</pkgmetadata>

--- a/sys-apps/systemd/metadata.xml
+++ b/sys-apps/systemd/metadata.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer>
+		<email>systemd@gentoo.org</email>
+		<name>Gentoo systemd team</name>
+	</maintainer>
+	<use>
+		<flag name="apparmor">Enable AppArmor support</flag>
+		<flag name="audit">Enable support for <pkg>sys-process/audit</pkg></flag>
+		<!-- TODO: drop reference to systemd-import once the oldest release in tree is >218 -->
+		<flag name="curl">Enable support for uploading journals; required to build systemd-import/systemd-pull</flag>
+		<flag name="cryptsetup">Enable cryptsetup tools (includes unit generator for crypttab)</flag>
+		<flag name="gnuefi">Enable EFI boot manager and stub loader (built using <pkg>sys-boot/gnu-efi</pkg>)</flag>
+		<flag name="elfutils">Enable coredump stacktraces in the journal</flag>
+		<!-- TODO: drop reference to systemd-import once the oldest release in tree is >218 -->
+		<flag name="gcrypt">Enable sealing of journal files using gcrypt; required to build systemd-import/systemd-pull</flag>
+		<flag name="gudev">enable libudev gobject interface</flag>
+		<flag name="http">Enable embedded HTTP server in journald</flag>
+		<flag name="importd">Enable import daemon</flag>
+		<flag name="kdbus">Connect to kernel dbus (KDBUS) instead of userspace dbus if available</flag>
+		<flag name="kmod">Enable kernel module loading via <pkg>sys-apps/kmod</pkg></flag>
+		<flag name="lz4">Enable lz4 compression for the journal</flag>
+		<flag name="nat">Enable support for network address translation in networkd</flag>
+		<flag name="qrcode">Enable qrcode output support in journal</flag>
+		<flag name="sysv-utils">Install sysvinit compatibility symlinks and manpages for init, telinit, halt, poweroff, reboot, runlevel, and shutdown</flag>
+		<flag name="terminal">Enable experimental userspace virtual terminal support</flag>
+		<flag name="vanilla">Disable Gentoo-specific behavior and compatibility quirks</flag>
+		<flag name="xkb">Validate XKB keymap in logind</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">systemd/systemd</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/sys-auth/polkit/metadata.xml
+++ b/sys-auth/polkit/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>freedesktop</herd>
+	<maintainer>
+		<email>freedesktop-bugs@gentoo.org</email>
+	</maintainer>
+	<use>
+		<flag name='systemd'>Use <pkg>sys-apps/systemd</pkg> instead of <pkg>sys-auth/consolekit</pkg> for session tracking</flag>
+	</use>
+</pkgmetadata>

--- a/sys-boot/grub/metadata.xml
+++ b/sys-boot/grub/metadata.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <herd>base-system</herd>
+  <maintainer>
+    <email>base-system@gentoo.org</email>
+  </maintainer>
+  <maintainer restrict="&gt;=sys-boot/grub-2">
+    <email>floppym@gentoo.org</email>
+    <name>Mike Gilbert</name>
+  </maintainer>
+  <use>
+    <flag name="device-mapper">
+		Enable support for device-mapper from <pkg>sys-fs/lvm2</pkg>
+	</flag>
+    <flag name="efiemu">
+		Build and install the efiemu runtimes
+	</flag>
+    <flag name="fonts">Build and install fonts for the gfxterm module</flag>
+    <flag name="mount">
+		Build and install the grub-mount utility
+	</flag>
+    <flag name="libzfs">
+		Enable support for <pkg>sys-fs/zfs</pkg>
+	</flag>
+    <flag name="multislot">
+		Allow concurrent installation of <pkg>sys-boot/grub:0</pkg> and
+		<pkg>sys-boot/grub:2</pkg> by renaming all programs.
+	</flag>
+    <flag name="themes">Build and install GRUB themes (starfield)</flag>
+    <flag name="truetype">Build and install grub-mkfont conversion utility</flag>
+  </use>
+  <upstream>
+    <remote-id type="sourceforge">dejavu</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/sys-boot/shim/metadata.xml
+++ b/sys-boot/shim/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/sys-boot/syslinux/metadata.xml
+++ b/sys-boot/syslinux/metadata.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+<maintainer>
+	<email>chithanh@gentoo.org</email>
+	<name>Chí-Thanh Christopher Nguyễn</name>
+</maintainer>
+<herd>base-system</herd>
+</pkgmetadata>

--- a/sys-devel/sysroot-wrappers/metadata.xml
+++ b/sys-devel/sysroot-wrappers/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/sys-firmware/edk2-ovmf/metadata.xml
+++ b/sys-firmware/edk2-ovmf/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/sys-kernel/bootengine/metadata.xml
+++ b/sys-kernel/bootengine/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/sys-kernel/coreos-firmware/metadata.xml
+++ b/sys-kernel/coreos-firmware/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/sys-kernel/coreos-kernel/metadata.xml
+++ b/sys-kernel/coreos-kernel/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/sys-kernel/coreos-sources/metadata.xml
+++ b/sys-kernel/coreos-sources/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/sys-libs/glibc/metadata.xml
+++ b/sys-libs/glibc/metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+<herd>toolchain</herd>
+<use>
+ <flag name='debug'>When USE=hardened, allow fortify/stack violations to dump core (SIGABRT) and not kill self (SIGKILL)</flag>
+ <flag name='gd'>build memusage and memusagestat tools</flag>
+ <flag name='nscd'>Build, and enable support for, the Name Service Cache Daemon</flag>
+ <flag name='suid'>Make internal pt_chown helper setuid -- not needed if using Linux and have /dev/pts mounted with gid=5</flag>
+ <flag name='systemtap'>enable systemtap static probe points</flag>
+</use>
+<upstream>
+ <remote-id type="cpe">cpe:/a:gnu:glibc</remote-id>
+</upstream>
+</pkgmetadata>

--- a/sys-libs/libbb/metadata.xml
+++ b/sys-libs/libbb/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/sys-libs/nss-usrfiles/metadata.xml
+++ b/sys-libs/nss-usrfiles/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer>
+		<email>ryao@gentoo.org</email>
+		<name>Richard Yao</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">coreos/nss-altfiles</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/sys-libs/pam/metadata.xml
+++ b/sys-libs/pam/metadata.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <herd>pam</herd>
+  <maintainer>
+    <email>pam-bugs@gentoo.org</email>
+  </maintainer>
+  <use>
+    <flag name='audit'>Enable support for <pkg>sys-process/audit</pkg></flag>
+
+    <flag name="berkdb">
+      Build the pam_userdb module, that allows to authenticate users
+      against a Berkeley DB file. Please note that enabling this USE
+      flag will create a PAM module that links to the Berkeley DB (as
+      provided by <pkg>sys-libs/db</pkg>) installed in /usr/lib and
+      will thus not work for boot-critical services authentication.
+    </flag>
+
+    <flag name="cracklib">
+      Build the pam_cracklib module, that allows to verify the chosen
+      passwords' strength through the use of
+      <pkg>sys-libs/cracklib</pkg>. Please note that simply enabling
+      the USE flag on this package will not make use of pam_cracklib
+      by default, you should also enable it in
+      <pkg>sys-auth/pambase</pkg> as well as update your configuration
+      files.
+    </flag>
+  </use>
+  <upstream>
+    <remote-id type="cpe">cpe:/a:kernel:linux-pam</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/sys-libs/talloc/metadata.xml
+++ b/sys-libs/talloc/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <herd>samba</herd>
+  <maintainer>
+    <email>patrick@gentoo.org</email>
+    <name>Patrick Lauer</name>
+  </maintainer>
+  <use>
+    <flag name="compat">Enable extra compatibility stuff</flag>
+  </use>
+</pkgmetadata>

--- a/sys-libs/timezone-data/metadata.xml
+++ b/sys-libs/timezone-data/metadata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <herd>toolchain</herd>
+  <maintainer>
+    <email>djc@gentoo.org</email>
+    <name>Dirkjan Ochtman</name>
+  </maintainer>
+  <use>
+    <flag name='leaps_timezone'>
+      Install the set of "right" timezones; these timezones include leap seconds
+      when counting seconds since the epoch (while POSIX does not) as they are
+      based on the TAI (International Atomic Time) clock
+    </flag>
+    <flag name='right_timezone'>
+      Install the set of "right" timezones; these timezones include leap seconds
+      when counting seconds since the epoch (while posix does not)
+    </flag>
+  </use>
+</pkgmetadata>

--- a/sys-process/audit/metadata.xml
+++ b/sys-process/audit/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer>
+    <email>robbat2@gentoo.org</email>
+  </maintainer>
+</pkgmetadata>

--- a/virtual/hard-host-depends-bsp/metadata.xml
+++ b/virtual/hard-host-depends-bsp/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/virtual/linux-sources/metadata.xml
+++ b/virtual/linux-sources/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>kernel</herd>
+	<maintainer>
+		<email>blueness@gentoo.org</email>
+		<name>Anthony G. Basile</name>
+	</maintainer>
+	<use>
+		<flag name="firmware">Install linux kernel firmware</flag>
+	</use>
+</pkgmetadata>

--- a/virtual/modemmanager/metadata.xml
+++ b/virtual/modemmanager/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/virtual/opengles/metadata.xml
+++ b/virtual/opengles/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/virtual/perf/metadata.xml
+++ b/virtual/perf/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/virtual/u-boot/metadata.xml
+++ b/virtual/u-boot/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>


### PR DESCRIPTION
Adds a metadata.xml file to any packages that are missing it.  If there is an
upstream gentoo metadata.xml file for the package, that is used, otherwise a
minimal metadata.xml is added.

Fixes equery errors like these:

  !!! Package XXX is missing metadata.xml
