### PR TITLE
app-emulation/docker: Fix bad WORKON_COMMIT

### DIFF
--- a/app-emulation/docker/docker-9999.ebuild
+++ b/app-emulation/docker/docker-9999.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} == *9999 ]]; then
 	DOCKER_GITCOMMIT="unknown"
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="9f9e6fd7733ad788f11890b6805de20ba0309c3f" # v1.7.1 with backports
+	CROS_WORKON_COMMIT="a2ddd68bdbd66f6684e626dacbf6adfff758020d" # v1.7.1 with backports
 	DOCKER_GITCOMMIT="${CROS_WORKON_COMMIT:0:7}"
 	KEYWORDS="amd64 arm64"
 fi


### PR DESCRIPTION
Commit 1ef6648b011c9f927e03de735da305376a2493a8 (app-emulation/docker: Update
CROS_WORKON_COMMIT for arm64) set CROS_WORKON_COMMIT to a bad revision.  This
change corrects it.
