### PR TITLE
profiles: re-enable debug symbols for board packages

### DIFF
--- a/profiles/coreos/amd64/generic/make.defaults
+++ b/profiles/coreos/amd64/generic/make.defaults
@@ -1,3 +1,3 @@
 # Enable optimizations for common x86_64 CPUs
-CFLAGS="-O2 -pipe -mtune=generic"
+CFLAGS="-O2 -pipe -mtune=generic -g"
 CXXFLAGS="${CFLAGS}"

--- a/profiles/coreos/arm64/generic/make.defaults
+++ b/profiles/coreos/arm64/generic/make.defaults
@@ -1,2 +1,2 @@
-CFLAGS="-O2 -pipe -mtune=generic"
+CFLAGS="-O2 -pipe -mtune=generic -g"
 CXXFLAGS="${CFLAGS}"


### PR DESCRIPTION
Commit f066db21 dropped generating debug symbols because at the time we
were never using them. Well we want to use them now. :)