### PR TITLE
coreos-sources: Add wl18xx firmware patch

### DIFF
--- a/sys-kernel/coreos-kernel/coreos-kernel-4.1.6-r2.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-4.1.6-r2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION="-r1"
+COREOS_SOURCE_REVISION="-r2"
 inherit coreos-kernel
 
 DESCRIPTION="CoreOS Linux kernel"

--- a/sys-kernel/coreos-sources/coreos-sources-4.1.6-r2.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-4.1.6-r2.ebuild
@@ -28,4 +28,5 @@ ${PATCH_DIR}/12-efi-Make-EFI_SECURE_BOOT_SIG_ENFORCE-depend-on-EFI.patch \
 ${PATCH_DIR}/13-efi-Add-EFI_SECURE_BOOT-bit.patch \
 ${PATCH_DIR}/14-hibernate-Disable-in-a-signed-modules-environment.patch \
 ${PATCH_DIR}/15-cpuset-use-trialcs-mems_allowed-as-a-temp-variable.patch \
-${PATCH_DIR}/udp-fix-dst-races-with-multicast-early-demux.patch"
+${PATCH_DIR}/udp-fix-dst-races-with-multicast-early-demux.patch \
+${PATCH_DIR}/net-wireless-wl18xx-Add-missing-MODULE_FIRMWARE.patch"

--- a/sys-kernel/coreos-sources/files/4.1/net-wireless-wl18xx-Add-missing-MODULE_FIRMWARE.patch
+++ b/sys-kernel/coreos-sources/files/4.1/net-wireless-wl18xx-Add-missing-MODULE_FIRMWARE.patch
@@ -1,0 +1,24 @@
+From 628cd64abeb364a53b86aa1dbbff151df536abfa Mon Sep 17 00:00:00 2001
+From: Geoff Levand <geoff@infradead.org>
+Date: Wed, 2 Sep 2015 16:08:30 -0700
+Subject: [PATCH] net/wireless/wl18xx: Add missing MODULE_FIRMWARE
+
+Fixes the output of 'modinfo --field firmware'.
+
+Signed-off-by: Geoff Levand <geoff@infradead.org>
+---
+ drivers/net/wireless/ti/wl18xx/main.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/net/wireless/ti/wl18xx/main.c b/drivers/net/wireless/ti/wl18xx/main.c
+index 49aca2c..3bbf624 100644
+--- a/drivers/net/wireless/ti/wl18xx/main.c
++++ b/drivers/net/wireless/ti/wl18xx/main.c
+@@ -2062,3 +2062,4 @@ MODULE_PARM_DESC(num_rx_desc_param,
+ MODULE_LICENSE("GPL v2");
+ MODULE_AUTHOR("Luciano Coelho <coelho@ti.com>");
+ MODULE_FIRMWARE(WL18XX_FW_NAME);
++MODULE_FIRMWARE(WL18XX_CONF_FILE_NAME);
+-- 
+2.1.0
+


### PR DESCRIPTION
Adds missing firmware for the Hikey developer board wireless controller.
Upstream patch from http://patchwork.kernerl.xyz/patch/7114261/
