### PR TITLE
profiles: upgrade to GCC 4.9

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -119,3 +119,8 @@ dev-util/checkbashisms
 =sys-apps/man-pages-4.00
 # Fixes conflict with man-pages 4.00
 =sys-apps/attr-2.4.47-r2
+
+# Upgrade to GCC 4.9, improves arm64 support, adds -fstack-protector-strong
+=sys-devel/gcc-4.9.3
+=cross-aarch64-cros-linux-gnu/gcc-4.9.3
+=cross-x86_64-cros-linux-gnu/gcc-4.9.3


### PR DESCRIPTION
We need this version for improved arm64 support and it has worth-while
improvements. None of the 4.9 related bugs in upstream should impact us:
https://bugs.gentoo.org/show_bug.cgi?id=495124

Depends on https://github.com/coreos/portage-stable/pull/264