### PR TITLE
profiles: set explicit ~arch keywords for gcc 4.9 cross compilers

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -121,6 +121,7 @@ dev-util/checkbashisms
 =sys-apps/attr-2.4.47-r2
 
 # Upgrade to GCC 4.9, improves arm64 support, adds -fstack-protector-strong
+# Note: ~arch for cross compilers much be explicit.
 =sys-devel/gcc-4.9.3
-=cross-aarch64-cros-linux-gnu/gcc-4.9.3
-=cross-x86_64-cros-linux-gnu/gcc-4.9.3
+=cross-aarch64-cros-linux-gnu/gcc-4.9.3 ~arm64
+=cross-x86_64-cros-linux-gnu/gcc-4.9.3  ~amd64


### PR DESCRIPTION
crossdev creates configs under `/etc/portage/package.keywords` like the following:

    cross-aarch64-cros-linux-gnu/binutils arm64 -amd64 -~amd64
    cross-aarch64-cros-linux-gnu/gcc arm64 -amd64 -~amd64
    cross-aarch64-cros-linux-gnu/linux-headers arm64 -amd64 -~amd64
    cross-aarch64-cros-linux-gnu/glibc arm64 -amd64 -~amd64
    cross-aarch64-cros-linux-gnu/gdb arm64 -amd64 -~amd64

This ensures cross compilers follow the keywords of the target arch
rather than the host arch. Meanwhile in the profile when we omit the
keyword `package.accept_keywords` only ~arch for the host is implied. So
either we would need to configure crossdev to allow ~arch or we just
need to be explicit in the profile. The later is a bit easer.