### PR TITLE
flannel: allow env file path to be overridden

### DIFF
--- a/app-admin/flannel/files/flanneld.service
+++ b/app-admin/flannel/files/flanneld.service
@@ -13,12 +13,13 @@ Environment="TMPDIR=/var/tmp/"
 Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
 Environment="FLANNEL_VER={{flannel_ver}}"
 Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
+Environment="FLANNEL_ENV_FILE=/run/flannel/options.env"
 LimitNOFILE=40000
 LimitNPROC=1048576
 ExecStartPre=/sbin/modprobe ip_tables
 ExecStartPre=/usr/bin/mkdir -p /run/flannel
 ExecStartPre=/usr/bin/mkdir -p ${ETCD_SSL_DIR}
-ExecStartPre=/usr/bin/touch /run/flannel/options.env
+ExecStartPre=-/usr/bin/touch ${FLANNEL_ENV_FILE}
 
 ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock \
   /usr/bin/docker run --net=host --privileged=true --rm \
@@ -26,7 +27,7 @@ ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock \
   --env=NOTIFY_SOCKET=/run/flannel/sd.sock \
   --env=AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
   --env=AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
-  --env-file=/run/flannel/options.env \
+  --env-file=${FLANNEL_ENV_FILE} \
   --volume=/usr/share/ca-certificates:/etc/ssl/certs:ro \
   --volume=${ETCD_SSL_DIR}:/etc/ssl/etcd:ro \
   quay.io/coreos/flannel:${FLANNEL_VER} /opt/bin/flanneld --ip-masq=true


### PR DESCRIPTION
The flannel options.env file isn't easily overridden in the default unit. This was an issue in https://github.com/coreos/coreos-kubernetes/pull/42 where the options file is not written via cloud-config at each boot, so we needed to symlink from /etc

Not sure this is the right approach, but ultimately hoping for an easier way to override this setting.