### PR TITLE
RFC: docker: use overlay driver on XFS

### DIFF
--- a/app-emulation/docker/files/dockerd
+++ b/app-emulation/docker/files/dockerd
@@ -46,7 +46,7 @@ select_docker_driver() {
         btrfs)
             export DOCKER_DRIVER=btrfs
             ;;
-        ext4|tmpfs) # As of 3.18
+        ext4|tmpfs|xfs) # As of 4.1
             export DOCKER_DRIVER=overlay
             ;;
         *)


### PR DESCRIPTION
We missed this back when 4.1 came out, but now here lies a conundrum:
what is docker's behavior if someone has an existing XFS volume? This
isn't a normal setup for us but it is possible someone has done it.