### PR TITLE
Add $DOCKER_OPTS to early-docker.service ExecStart

### DIFF
--- a/app-emulation/docker/files/early-docker.service
+++ b/app-emulation/docker/files/early-docker.service
@@ -9,7 +9,7 @@ Environment=TMPDIR=/var/tmp
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576
-ExecStart=/usr/lib/coreos/dockerd daemon --host=fd:// --bridge=none --iptables=false --ip-masq=false --graph=/var/lib/early-docker --pidfile=/var/run/early-docker.pid
+ExecStart=/usr/lib/coreos/dockerd daemon --host=fd:// --bridge=none --iptables=false --ip-masq=false --graph=/var/lib/early-docker --pidfile=/var/run/early-docker.pid $DOCKER_OPTS
 
 [Install]
 WantedBy=early-docker.target


### PR DESCRIPTION
Provide the ability to easily use extra docker options via a drop-in when early-docker starts up.