### PR TITLE
profiles/coreos: enable pcre use flag

### DIFF
--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -16,7 +16,7 @@ USE_EXPAND="${USE_EXPAND} ETCD_PROTOCOLS"
 ETCD_PROTOCOLS="1 2"
 
 # Extra use flags for CoreOS SDK
-USE="${USE} cros_host expat -introspection -cups -tcpd -pcre -berkdb"
+USE="${USE} cros_host expat -introspection -cups -tcpd -berkdb"
 
 # Never install cron or cron jobs
 USE="${USE} -cron"


### PR DESCRIPTION
current this turns on pcre for grep, less, swig and wget.

fixes coreos/bugs#906