### PR TITLE
Enabled epoll for libmicrohttpd and systemd-journal-remote

### DIFF
--- a/profiles/coreos/targets/generic/package.use
+++ b/profiles/coreos/targets/generic/package.use
@@ -25,7 +25,8 @@ sys-libs/gdbm		berkdb
 # enable journal gateway and container features, avoid pulling in gnutls
 sys-apps/systemd audit importd http nat -ssl
 
-net-libs/libmicrohttpd -ssl
+# epoll is needed for systemd-journal-remote to work. coreos/bugs#919
+net-libs/libmicrohttpd epoll -ssl
 
 sys-boot/syslinux       -custom-cflags
 


### PR DESCRIPTION
@mischief @marineam @crawford 

resolves https://github.com/coreos/bugs/issues/919