### PR TITLE
WIP: Docker 1.9

### DIFF
--- a/app-emulation/docker/docker-9999.ebuild
+++ b/app-emulation/docker/docker-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} == *9999 ]]; then
 	DOCKER_GITCOMMIT="unknown"
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="cedd53482c5a3ce88f3bb98d1d325dae4c95d9b6" # v1.8.3 with backports
+	CROS_WORKON_COMMIT="76d6bc9a9f1690e16f3721ba165364688b626de2" # v1.9.0
 	DOCKER_GITCOMMIT="${CROS_WORKON_COMMIT:0:7}"
 	KEYWORDS="amd64"
 fi


### PR DESCRIPTION
In a shocking turn of events this release has an odd behavior. `docker pull` doesn't work on a fresh system:

```
core@coreos_production_qemu-845-0-0-2 ~ $ docker pull ubuntu
Using default tag: latest
Error response from daemon: 404 page not found
core@coreos_production_qemu-845-0-0-2 ~ $ docker pull ubuntu
Using default tag: latest
Error response from daemon: 404 page not found
core@coreos_production_qemu-845-0-0-2 ~ $ docker pull busybox
Using default tag: latest
Error response from daemon: 404 page not found
core@coreos_production_qemu-845-0-0-2 ~ $ docker run busybox 
Unable to find image 'busybox:latest' locally
latest: Pulling from library/busybox

039b63dd2cba: Pull complete 
c51f86c28340: Pull complete 
Digest: sha256:87fcdf79b696560b61905297f3be7759e01130a4befdfe2cc9ece9234bbbab6f
Status: Downloaded newer image for busybox:latest
core@coreos_production_qemu-845-0-0-2 ~ $ docker run -t -i ubuntu
Unable to find image 'ubuntu:latest' locally
latest: Pulling from library/ubuntu
c63fb41c2213: Pull complete 
99fcaefe76ef: Pull complete 
5a4526e952f0: Pull complete 
1d073211c498: Pull complete 
Digest: sha256:8b1bffa54d8a58395bae61ec32f1a70fc82a939e4a7179e6227eb79e4c3c56f6
Status: Downloaded newer image for ubuntu:latest
root@d0888aeff789:/# exit
^[[Acore@coreos_production_qemu-845-0-0-2 ~ $ docker pull busybox
Using default tag: latest
latest: Pulling from library/busybox
Digest: sha256:87fcdf79b696560b61905297f3be7759e01130a4befdfe2cc9ece9234bbbab6f
Status: Image is up to date for busybox:latest
core@coreos_production_qemu-845-0-0-2 ~ $ docker pull fedora 
Using default tag: latest
latest: Pulling from library/fedora
369aca82a5c0: Pull complete 
a887c7ad7f3f: Pull complete 
Digest: sha256:a220110e096cd1d6034699a5e30a012de6c55c83149d01658120918d01f1587a
Status: Downloaded newer image for fedora:latest
```