### PR TITLE
sys-kernel/coreos-sources: fix return value of switchdev_port_fdb_dump()

### DIFF
--- a/sys-kernel/coreos-kernel/coreos-kernel-4.2.2-r8.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-4.2.2-r8.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION="-r1"
+COREOS_SOURCE_REVISION="-r2"
 inherit coreos-kernel
 
 DESCRIPTION="CoreOS Linux kernel"

--- a/sys-kernel/coreos-sources/coreos-sources-4.2.2-r2.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-4.2.2-r2.ebuild
@@ -33,4 +33,6 @@ ${PATCH_DIR}/overlayfs/0003-SELinux-Stub-in-copy-up-handling.patch \
 ${PATCH_DIR}/overlayfs/0004-SELinux-Handle-opening-of-a-unioned-file.patch \
 ${PATCH_DIR}/overlayfs/0005-SELinux-Check-against-union-label-for-file-operation.patch \
 ${PATCH_DIR}/overlayfs/0006-overlayfs-use-a-minimal-buffer-in-ovl_copy_xattr.patch \
-${PATCH_DIR}/net-wireless-wl18xx-Add-missing-MODULE_FIRMWARE.patch"
+${PATCH_DIR}/net-wireless-wl18xx-Add-missing-MODULE_FIRMWARE.patch \
+${PATCH_DIR}/0021-switchdev-fix-return-value-of-switchdev_port_fdb_dum.patch \
+${PATCH_DIR}/0022-net-switchdev-fix-return-code-of-fdb_dump-stub.patch"

--- a/sys-kernel/coreos-sources/files/4.2/0021-switchdev-fix-return-value-of-switchdev_port_fdb_dum.patch
+++ b/sys-kernel/coreos-sources/files/4.2/0021-switchdev-fix-return-value-of-switchdev_port_fdb_dum.patch
@@ -1,0 +1,39 @@
+From a380cc22a956afb1370cf8f4c6708a25b2d6d1f5 Mon Sep 17 00:00:00 2001
+From: Jiri Pirko <jiri@mellanox.com>
+Date: Thu, 3 Sep 2015 14:04:17 +0200
+Subject: [PATCH 21/22] switchdev: fix return value of switchdev_port_fdb_dump
+ in case of error
+
+switchdev_port_fdb_dump is used as .ndo_fdb_dump. Its return value is
+idx, so we cannot return errval.
+
+Fixes: 45d4122ca7cd ("switchdev: add support for fdb add/del/dump via switchdev_port_obj ops.")
+Signed-off-by: Jiri Pirko <jiri@mellanox.com>
+Acked-by: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Acked-by: Scott Feldman<sfeldma@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ net/switchdev/switchdev.c | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/net/switchdev/switchdev.c b/net/switchdev/switchdev.c
+index 9f2add3..6a566cd 100644
+--- a/net/switchdev/switchdev.c
++++ b/net/switchdev/switchdev.c
+@@ -853,12 +853,8 @@ int switchdev_port_fdb_dump(struct sk_buff *skb, struct netlink_callback *cb,
+ 		.cb = cb,
+ 		.idx = idx,
+ 	};
+-	int err;
+-
+-	err = switchdev_port_obj_dump(dev, &dump.obj);
+-	if (err)
+-		return err;
+ 
++	switchdev_port_obj_dump(dev, &dump.obj);
+ 	return dump.idx;
+ }
+ EXPORT_SYMBOL_GPL(switchdev_port_fdb_dump);
+-- 
+2.4.6
+

--- a/sys-kernel/coreos-sources/files/4.2/0022-net-switchdev-fix-return-code-of-fdb_dump-stub.patch
+++ b/sys-kernel/coreos-sources/files/4.2/0022-net-switchdev-fix-return-code-of-fdb_dump-stub.patch
@@ -1,0 +1,38 @@
+From d5eda9e85df6d1894d0d16155e0900daadb4ce1b Mon Sep 17 00:00:00 2001
+From: Dragos Tatulea <dragos@endocode.com>
+Date: Mon, 16 Nov 2015 10:52:48 +0100
+Subject: [PATCH 22/22] net: switchdev: fix return code of fdb_dump stub
+
+rtnl_fdb_dump always expects an index to be returned by the ndo_fdb_dump op,
+but when CONFIG_NET_SWITCHDEV is off, it returns an error.
+
+Fix that by returning the given unmodified idx.
+
+A similar fix was 0890cf6cb6ab ("switchdev: fix return value of
+switchdev_port_fdb_dump in case of error") but for the CONFIG_NET_SWITCHDEV=y
+case.
+
+Fixes: 45d4122ca7cd ("switchdev: add support for fdb add/del/dump via switchdev_port_obj ops.")
+Signed-off-by: Dragos Tatulea <dragos@endocode.com>
+Acked-by: Jiri Pirko <jiri@mellanox.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ include/net/switchdev.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/net/switchdev.h b/include/net/switchdev.h
+index d5671f1..0b91979 100644
+--- a/include/net/switchdev.h
++++ b/include/net/switchdev.h
+@@ -268,7 +268,7 @@ static inline int switchdev_port_fdb_dump(struct sk_buff *skb,
+ 					  struct net_device *filter_dev,
+ 					  int idx)
+ {
+-	return -EOPNOTSUPP;
++       return idx;
+ }
+ 
+ #endif
+-- 
+2.4.6
+


### PR DESCRIPTION
Fixes https://github.com/coreos/bugs/issues/980