### PR TITLE
go: disable arm64-extras flag, currently broken

### DIFF
--- a/dev-lang/go/go-9999.ebuild
+++ b/dev-lang/go/go-9999.ebuild
@@ -23,7 +23,7 @@ HOMEPAGE="http://www.golang.org"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-IUSE="cros_host +arm64-extras"
+IUSE="cros_host arm64-extras"
 
 DEPEND="cros_host? ( >=dev-lang/go-bootstrap-1.4.1 )"
 RDEPEND=""


### PR DESCRIPTION
For some reason the arm64 build (intended only for generating a
pre-built std library) is leaking into the amd64 build, leaving the
installed `go` binary with the arm64 defaults compiled in.

Until this is resolved disable building the arm64 std library.
