### PR TITLE
app-emulation/docker: Set libdm_no_deferred_remove

### DIFF
--- a/app-emulation/docker/docker-1.7.1-r6.ebuild
+++ b/app-emulation/docker/docker-1.7.1-r6.ebuild
@@ -188,6 +188,10 @@ src_compile() {
 		fi
 	done
 
+	# Docker uses the host files when testing, so force docker
+	# to not use dm_task_deferred_remove to cover cross builds.
+	DOCKER_BUILDTAGS+=' libdm_no_deferred_remove'
+
 	# https://github.com/docker/docker/pull/13338
 	if use experimental; then
 		export DOCKER_EXPERIMENTAL=1


### PR DESCRIPTION
Fix docker 1.7.1 build errors.

Signed-off-by: Geoff Levand <geoff@infradead.org>