### PR TITLE
coreos-kernel: populate /lib/modules/$(uname -r)/build

### DIFF
--- a/sys-kernel/coreos-kernel/coreos-kernel-4.3.0-r2.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-4.3.0-r2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION=""
+COREOS_SOURCE_REVISION="-r1"
 inherit coreos-kernel
 
 DESCRIPTION="CoreOS Linux kernel"

--- a/sys-kernel/coreos-sources/coreos-sources-4.3.0-r1.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-4.3.0-r1.ebuild
@@ -37,5 +37,6 @@ UNIPATCH_LIST="
         ${PATCH_DIR}/0019-net-wireless-wl18xx-Add-missing-MODULE_FIRMWARE.patch \
         ${PATCH_DIR}/0020-overlayfs-use-a-minimal-buffer-in-ovl_copy_xattr.patch \
         ${PATCH_DIR}/0021-net-switchdev-fix-return-code-of-fdb_dump-stub.patch \
+        ${PATCH_DIR}/0022-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch \
 "
 

--- a/sys-kernel/coreos-sources/files/4.3/0022-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch
+++ b/sys-kernel/coreos-sources/files/4.3/0022-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch
@@ -1,0 +1,30 @@
+From 3348a15e9733c3ffb56ad7f9e9729a919f61eee9 Mon Sep 17 00:00:00 2001
+From: Vito Caputo <vito.caputo@coreos.com>
+Date: Wed, 25 Nov 2015 02:59:45 -0800
+Subject: [PATCH 22/22] kbuild: derive relative path for KBUILD_SRC from CURDIR
+
+This enables relocating source and build trees to different roots,
+provided they stay reachable relative to one another.  Useful for
+builds done within a sandbox where the eventual root is prefixed
+by some undesirable path component.
+---
+ Makefile | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index d5b3739..f64d968 100644
+--- a/Makefile
++++ b/Makefile
+@@ -143,7 +143,8 @@ $(filter-out _all sub-make $(CURDIR)/Makefile, $(MAKECMDGOALS)) _all: sub-make
+ 	@:
+ 
+ sub-make: FORCE
+-	$(Q)$(MAKE) -C $(KBUILD_OUTPUT) KBUILD_SRC=$(CURDIR) \
++	$(Q)$(MAKE) -C $(KBUILD_OUTPUT) \
++	KBUILD_SRC=$(shell realpath --relative-to=$(KBUILD_OUTPUT) $(CURDIR)) \
+ 	-f $(CURDIR)/Makefile $(filter-out _all sub-make,$(MAKECMDGOALS))
+ 
+ # Leave processing to above invocation of make
+-- 
+2.4.6
+


### PR DESCRIPTION
With this changeset one can build a kernel module out-of-tree in a dev
image in the usual fashion:
```
 ~# cat Makefile
 obj-m := noop.o
 ~# make -C /lib/modules/4.3.0-coreos-r1/build M=$PWD
 make: Entering directory '/usr/lib64/modules/4.3.0-coreos-r1/build'
   CC [M]  /tmp/noop/noop.o
   Building modules, stage 2.
   MODPOST 1 modules
   CC      /tmp/noop/noop.mod.o
   LD [M]  /tmp/noop/noop.ko
 make: Leaving directory '/usr/lib64/modules/4.3.0-coreos-r1/build'
 ~#
```

/lib/modules/$(uname -r)/source is now populated with a stripped source
tree (headers, scripts, Makefiles...), prod images may build out-of-tree
modules by simply bind mounting these directories into a toolchain
container without needing kernel source.

Note that this build directory is being populated from the _actual_
$KBUILD_OUTPUT used in producing the kernel in the image, which has simply
been `make clean`ed and stripped down:

```
 /lib/modules/4.3.0-coreos-r1/build# ls -la
 drwxr-xr-x 5 root root   4096 Nov 25 11:56 .
 drwxr-xr-x 4 root root   4096 Nov 25 11:56 ..
 -rw-r--r-- 1 root root 108265 Nov 25 11:52 .config
 -rw-r--r-- 1 root root      2 Nov 25 11:55 .version
 -rw-r--r-- 1 root root    578 Nov 25 11:54 Makefile
 -rw-r--r-- 1 root root 617170 Nov 25 11:55 Module.symvers
 drwxr-xr-x 3 root root   4096 Nov 25 11:23 arch
 -rw-r--r-- 1 root root  23280 Nov 25 11:52 defconfig
 drwxr-xr-x 4 root root   4096 Nov 25 11:23 include
 drwxr-xr-x 6 root root   4096 Nov 25 11:56 scripts
 lrwxrwxrwx 1 root root      9 Nov 25 11:56 source -> ../source
 /lib/modules/4.3.0-coreos-r1/build#
```