### PR TITLE
dev-db/etcd: Fix unstable build error

### DIFF
--- a/dev-db/etcd/etcd-9999.ebuild
+++ b/dev-db/etcd/etcd-9999.ebuild
@@ -12,6 +12,7 @@ COREOS_GO_PACKAGE="github.com/coreos/etcd"
 inherit coreos-doc coreos-go toolchain-funcs cros-workon systemd
 
 if [[ "${PV}" == 9999 ]]; then
+    CROS_WORKON_COMMIT=${CROS_WORKON_COMMIT:="HEAD"}
     KEYWORDS="~amd64 ~arm64"
 else
     CROS_WORKON_COMMIT="b4bddf685b26b4aa70e939445044bdeac822d042" # v2.2.2


### PR DESCRIPTION
Define a value for CROS_WORKON_COMMIT to avoid build errors when building etcd unstable.
Also, add an equals sign to GO_LDFLAGS to fix build warnings like:

  link: warning: option '-X version.GitSHA XXX' may not work in future releases
