### PR TITLE
profiles/coreos/base: use btrfs-progs 4.2.2 for fixes and features

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -134,3 +134,7 @@ dev-util/checkbashisms
 =app-misc/c_rehash-1.7-r1 ~amd64 ~arm64
 =dev-libs/openssl-1.0.2e ~amd64 ~arm64
 
+# newer btrfs-progs improve things like preserving capabilities in send/receive
+# https://github.com/coreos/bugs/issues/923
+=sys-fs/btrfs-progs-4.2.2 ~amd64 ~arm64
+


### PR DESCRIPTION
fixes coreos/bugs#923