### PR TITLE
Use defined ETCD_SSL_DIR path inside the flannel container

### DIFF
--- a/app-admin/flannel/files/flanneld.service
+++ b/app-admin/flannel/files/flanneld.service
@@ -29,7 +29,7 @@ ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock \
   --env=AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
   --env-file=${FLANNEL_ENV_FILE} \
   --volume=/usr/share/ca-certificates:/etc/ssl/certs:ro \
-  --volume=${ETCD_SSL_DIR}:/etc/ssl/etcd:ro \
+  --volume=${ETCD_SSL_DIR}:${ETCD_SSL_DIR}:ro \
   quay.io/coreos/flannel:${FLANNEL_VER} /opt/bin/flanneld --ip-masq=true
 
 # Update docker options


### PR DESCRIPTION
Flannel TLS configuration is kinda confusing... When you would like to configure custom keys path you have to set custom `ETCD_SSL_DIR` environment variable, but the actual path to the keys should be `/etc/ssl/etcd`.

This fix tells docker to use same destination path.