### PR TITLE
preserve 'System.map' during kernel build

### DIFF
--- a/eclass/coreos-kernel.eclass
+++ b/eclass/coreos-kernel.eclass
@@ -156,6 +156,11 @@ prepare-lib-modules-release-dirs() {
 		"${D}/usr/lib/modules/${version}" || die
 
 	# Clean up the build tree and install for out-of-tree module builds
+	find "build/" -follow -maxdepth 1 -name 'System.map' -print \
+		| cpio -pd \
+		--preserve-modification-time \
+		--owner=root:root \
+		"${D}/usr/lib/modules/${version}" || die
 	kmake clean
 	find "build/" -type d -empty -delete || die
 	rm --recursive \


### PR DESCRIPTION
allows the proper operation of 'depmod' when building out-of-tree modules