### PR TITLE
glibc: ensure cross-rpcgen is compiled during the compile phase

### DIFF
--- a/sys-libs/glibc/files/eblits/src_compile.eblit
+++ b/sys-libs/glibc/files/eblits/src_compile.eblit
@@ -14,9 +14,21 @@ toolchain-glibc_src_compile() {
 	done
 }
 
+## COREOS: fix compilation of cross-rpcgen during compiler bootstrap
+toolchain-glibc_headers_compile() {
+	[[ ${EAPI:-0} == [01] ]] && toolchain-glibc_headers_configure
+
+	tc-export_build_env
+	local builddir=$(builddir "headers")
+	cd "${builddir}"
+	emake -C "${S}/sunrpc" subdir=sunrpc objdir="${builddir}" \
+		"${builddir}/sunrpc/cross-rpcgen" || die "make cross-rpcgen failed"
+}
+
 eblit-glibc-src_compile() {
 	if just_headers ; then
-		[[ ${EAPI:-0} == [01] ]] && toolchain-glibc_headers_configure
+		export ABI=default
+		toolchain-glibc_headers_compile
 		return
 	fi
 


### PR DESCRIPTION
When bootstrapping glibc installs headers but is not built. However a
native tool, cross-rpcgen, must be built in order to generate rpcsvc
header files. By skipping directly to `make headers-install` the tool
winds up getting built during src_install, building as root instead of
the portage user and so on. Although uncommon this may lead to
permission issues with ccache.