### PR TITLE
coreos-kernel: prune old ebuild

### DIFF
--- a/sys-kernel/coreos-kernel/coreos-kernel-4.3.0-r4.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-4.3.0-r4.ebuild
@@ -1,9 +1,0 @@
-# Copyright 2014 CoreOS, Inc.
-# Distributed under the terms of the GNU General Public License v2
-
-EAPI=5
-COREOS_SOURCE_REVISION="-r1"
-inherit coreos-kernel
-
-DESCRIPTION="CoreOS Linux kernel"
-KEYWORDS="amd64 arm64"


### PR DESCRIPTION
This kernel doesn't have the corresponding sources any more.