### PR TITLE
sys-apps/shadow: split shadow.conf

### DIFF
--- a/sys-apps/shadow/files/tmpfiles.d/etc-shadow.conf
+++ b/sys-apps/shadow/files/tmpfiles.d/etc-shadow.conf
@@ -5,6 +5,3 @@ L   /etc/securetty      -   -   -   -   ../usr/share/shadow/securetty
 
 d   /etc/default            -   -   -   -   -
 L   /etc/default/useradd    -   -   -   -   ../../usr/share/shadow/useradd
-
-f   /var/log/lastlog        -   -   -   -   -
-f   /var/log/faillog        -   -   -   -   -

--- a/sys-apps/shadow/files/tmpfiles.d/var-shadow.conf
+++ b/sys-apps/shadow/files/tmpfiles.d/var-shadow.conf
@@ -1,0 +1,2 @@
+f   /var/log/lastlog        -   -   -   -   -
+f   /var/log/faillog        -   -   -   -   -

--- a/sys-apps/shadow/shadow-4.1.5.1-r4.ebuild
+++ b/sys-apps/shadow/shadow-4.1.5.1-r4.ebuild
@@ -78,7 +78,11 @@ src_install() {
 
 	# Remove files from /etc, they will be symlinks to /usr instead.
 	rm -f "${D}"/etc/{limits,login.access,login.defs,securetty,default/useradd}
-	systemd_dotmpfilesd "${FILESDIR}"/tmpfiles.d/shadow.conf
+
+	# CoreOS: break shadow.conf into two files so that we only have to apply
+	# etc-shadow.conf in the initrd.
+	systemd_dotmpfilesd "${FILESDIR}"/tmpfiles.d/etc-shadow.conf
+	systemd_dotmpfilesd "${FILESDIR}"/tmpfiles.d/var-shadow.conf
 
 	insinto /usr/share/shadow
 	# Using a securetty with devfs device names added


### PR DESCRIPTION
This will allow bootengine to only apply the shadow config that applies to /etc.