### PR TITLE
app-admin/kubelet: kubelet-service now runs kubelet via rkt

### DIFF
--- a/app-admin/kubelet/files/kubelet.service
+++ b/app-admin/kubelet/files/kubelet.service
@@ -1,18 +1,52 @@
 [Unit]
 Description=Kubernetes Kubelet
-Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+Documentation=http://kubernetes.io
 
 [Service]
+
+# If left empty the kubelet will fail to start. Set in
+# /run/kubelet/options.env.
+Environment=KUBELET_VERSION=
+
+# Kubelet App Container Image name:
+Environment=KUBELET_ACI=quay.io/coreos/hyperkube
+
+# CLI flags to pass to the Kubelet binary
 Environment=KUBELET_OPTS=
 
-ExecStart=/usr/bin/kubelet \
- --address=127.0.0.1 \
- --api-servers=http://127.0.0.1:8080 \
- --allow-privileged=false \
- --config=/etc/kubernetes/manifests \
- --v=2 \
- --cadvisor-port=0 \
- $KUBELET_OPTS
+# These are the default mount/volume options necessary for running the Kubelet in a rkt container.
+Environment='KUBELET_RKT_FLAGS=\
+  --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
+  --volume etc-ssl-certs,kind=host,source=/usr/share/ca-certificates \
+  --volume var-lib-docker,kind=host,source=/var/lib/docker \
+  --volume var-lib-kubelet,kind=host,source=/var/lib/kubelet \
+  --volume run,kind=host,source=/run \
+  --mount volume=etc-kubernetes,target=/etc/kubernetes \
+  --mount volume=etc-ssl-certs,target=/etc/ssl/certs \
+  --mount volume=var-lib-docker,target=/var/lib/docker \
+  --mount volume=var-lib-kubelet,target=/var/lib/kubelet \
+  --mount volume=run,target=/run'
+
+ExecStartPre=/usr/bin/mkdir --parents /etc/kubernetes/manifests
+ExecStartPre=/usr/bin/mkdir --parents /var/lib/docker
+ExecStartPre=/usr/bin/mkdir --parents /var/lib/kubelet
+ExecStartPre=/usr/bin/mkdir --parents /run/kubelet
+
+# ENV options can be overridden here
+EnvironmentFile=-/run/kubelet/options.env
+
+# Require KUBELET_VERSION env to be set
+ExecStartPre=[ -z "$KUBELET_VERSION" ] && { echo "Need to set KUBELET_VERSION"; exit 1; }
+
+ExecStart=usr/bin/rkt run $KUBELET_RKT_FLAGS \
+    --stage1-image=/usr/share/rkt/stage1-fly.aci \
+    --exec, /hyperkube -- kubelet \
+    --address=127.0.0.1 \
+    --api-servers=http://127.0.0.1:8080 \
+    --allow-privileged=false \
+    --config=/etc/kubernetes/manifests \
+    --cadvisor-port=0 \
+    $KUBELET_OPTS
 
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
This PR supersedes https://github.com/coreos/coreos-overlay/pull/1726. This changes the kubelet.service file from using the on-disk disk kubelet to running a kubelet aci specified by the user.

This divorces the kubelet version from the OS but does not provide an update strategy besides specifying which hyperkube aci to run the kubelet from. The on-disk kubelet can eventually be phased out independently.

$KUBELET_VERSION must be explicitly set or the service will fail on start.