### PR TITLE
sys-apps/shadow: increase minimum password length

### DIFF
--- a/sys-apps/shadow/shadow-4.1.5.1-r5.ebuild
+++ b/sys-apps/shadow/shadow-4.1.5.1-r5.ebuild
@@ -123,6 +123,9 @@ src_install() {
 		set_login_opt CRACKLIB_DICTPATH /usr/$(get_libdir)/cracklib_dict
 		set_login_opt LOGIN_RETRIES 3
 		set_login_opt ENCRYPT_METHOD SHA512
+
+		# CoreOS: increase the minimum password length to eight
+		set_login_opt PASS_MIN_LEN 8
 	else
 		dopamd "${FILESDIR}"/pam.d-include/shadow
 


### PR DESCRIPTION
Several cloud providers have requested that the minimum password length be
increased to eight.