### PR TITLE
dev-db/etcd: Set CROS_WORKON_COMMIT for arm64

### DIFF
--- a/dev-db/etcd/etcd-9999.ebuild
+++ b/dev-db/etcd/etcd-9999.ebuild
@@ -14,6 +14,11 @@ inherit coreos-doc coreos-go toolchain-funcs cros-workon systemd
 if [[ "${PV}" == 9999 ]]; then
     CROS_WORKON_COMMIT=${CROS_WORKON_COMMIT:="HEAD"}
     KEYWORDS="~amd64 ~arm64"
+elif [[ "${ARCH}" == "arm64" ]]; then
+    # etcd-2.2.4 build fails for arm64
+    # https://github.com/coreos/etcd/issues/3623
+    CROS_WORKON_COMMIT="4669b899cca9a326731a10e03c76605bf26470f6"
+    KEYWORDS="arm64"
 else
     CROS_WORKON_COMMIT="bdee27b19e8601ffd7bd4f0481abe9bbae04bd09" # v2.2.4
     KEYWORDS="amd64 arm64"


### PR DESCRIPTION
The current CROS_WORKON_COMMIT of etcd-2.2.4 does not build for
arm64.  Add a temporary conditional to set CROS_WORKON_COMMIT to
a known good revision for arm64.
