### PR TITLE
coreos-kernel: Add verbose build

### DIFF
--- a/eclass/coreos-kernel.eclass
+++ b/eclass/coreos-kernel.eclass
@@ -120,6 +120,7 @@ kmake() {
 		KBUILD_OUTPUT="../build" \
 		KCFLAGS="${kernel_cflags}" \
 		LDFLAGS="" \
+		"V=1" \
 		"$@"
 }
 


### PR DESCRIPTION
To aid in debugging kernel builds set the kernel make variable
V=1 to get verbose build output when ECLASS_DEBUG_OUTPUT is
set.
