### PR TITLE
profiles/coreos: accept app-misc/jq-1.5-r1

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -65,7 +65,6 @@ net-fs/nfs-utils ~arm64
 =net-firewall/ipset-6.24 **
 =sys-fs/mdadm-3.3.2-r1 **
 =sys-apps/rng-tools-5 **
-=app-misc/jq-1.4-r1 **
 
 =net-misc/iperf-3.0.7 **
 =dev-libs/liblinear-196-r1 **

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -56,8 +56,8 @@ dev-util/checkbashisms
 # Fixes findmnt with overlay and btrfs filesystems
 =sys-apps/util-linux-2.26.1
 
-# link jq binary dynamically
-=app-misc/jq-1.4-r1
+# 1.5 has fixed version string. coreos/bugs#455
+=app-misc/jq-1.5-r1 ~amd64 ~arm64
 
 # https://bugs.gentoo.org/show_bug.cgi?id=548158
 =sys-apps/gentoo-functions-0.10


### PR DESCRIPTION
depends on coreos/portage-stable#385

fixes coreos/bugs#455