### PR TITLE
coreos-base/coreos-cloudinit: re-add arm64 keyword

### DIFF
--- a/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
+++ b/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
@@ -12,7 +12,7 @@ if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
 	CROS_WORKON_COMMIT="6e9109eaa44da8734ea4c8b8aa9560fb1f6d57d3" # tag v1.9.2
-	KEYWORDS="amd64"
+	KEYWORDS="amd64 arm64"
 fi
 
 DESCRIPTION="coreos-cloudinit"


### PR DESCRIPTION
This was dropped in 0cf04c447ce67f48f8546d745742ca22e5b8e603.