### PR TITLE
profiles: add go-1.5.3 to accepted keywords

### DIFF
--- a/dev-lang/go/go-9999.ebuild
+++ b/dev-lang/go/go-9999.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} = 9999 ]]; then
 else
 	SRC_URI="https://storage.googleapis.com/golang/go${PV}.src.tar.gz"
 	# arm64 only works when cross-compiling in the SDK
-	KEYWORDS="-* ~amd64 ~arm arm64 ~x86 ~amd64-fbsd ~x86-fbsd ~x64-macos ~x86-macos"
+	KEYWORDS="-* amd64 ~arm arm64 ~x86 ~amd64-fbsd ~x86-fbsd ~x64-macos ~x86-macos"
 fi
 
 DESCRIPTION="A concurrent garbage collected and typesafe programming language"

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -76,10 +76,6 @@ dev-util/checkbashisms
 =cross-aarch64-cros-linux-gnu/gcc-4.9.3 ~arm64
 =cross-x86_64-cros-linux-gnu/gcc-4.9.3  ~amd64
 
-# go 1.4.3 includes a number of security fixes.
-# https://github.com/golang/go/issues?q=milestone%3AGo1.4.3
-=dev-lang/go-1.4.3 ~amd64
-
 # newer btrfs-progs improve things like preserving capabilities in send/receive
 # https://github.com/coreos/bugs/issues/923
 =sys-fs/btrfs-progs-4.2.2 ~amd64 ~arm64


### PR DESCRIPTION
This ought to be interesting. Let's hold off on merging this until the Alpha is cut.