### PR TITLE
coreos-overlay: cease ForwardToConsole in journald

### DIFF
--- a/coreos-base/oem-azure/files/grub.cfg
+++ b/coreos-base/oem-azure/files/grub.cfg
@@ -3,7 +3,7 @@
 set oem_id="azure"
 
 # Azure only has a serial console.
-set linux_console="console=ttyS0,115200n8 earlyprintk=ttyS0,115200 systemd.journald.forward_to_console=yes"
+set linux_console="console=ttyS0,115200n8 earlyprintk=ttyS0,115200"
 serial com0 --speed=115200 --word=8 --parity=no
 terminal_input serial_com0
 terminal_output serial_com0

--- a/coreos-base/oem-ec2-compat/files/grub-ec2.cfg
+++ b/coreos-base/oem-ec2-compat/files/grub-ec2.cfg
@@ -4,4 +4,4 @@ set oem_id="ec2"
 
 # Blacklist the Xen framebuffer module so it doesn't get loaded at boot
 # Disable `ens3` style names, so eth0 is used for both ixgbevf or xen.
-set linux_append="modprobe.blacklist=xen_fbfront net.ifnames=0 systemd.journald.forward_to_console=yes"
+set linux_append="modprobe.blacklist=xen_fbfront net.ifnames=0"

--- a/coreos-base/oem-gce/files/grub.cfg
+++ b/coreos-base/oem-gce/files/grub.cfg
@@ -3,7 +3,6 @@
 set oem_id="gce"
 
 # GCE only has a serial console.
-set linux_append="systemd.journald.forward_to_console=yes"
 set linux_console="console=ttyS0,115200n8"
 serial com0 --speed=115200 --word=8 --parity=no
 terminal_input serial_com0


### PR DESCRIPTION
This was introduced to assist users in troubleshooting on cloud
providers without an interactive console but with read-only access to
console output.

However, due to how journald implements the forwarding (synchronously)
it can have a dramatic impact on the overall logging performance.

Fixes https://github.com/coreos/bugs/issues/1162