### PR TITLE
profiles: remove *.h from prod INSTALL_MASK

### DIFF
--- a/profiles/coreos/targets/generic/prod/make.defaults
+++ b/profiles/coreos/targets/generic/prod/make.defaults
@@ -3,9 +3,10 @@
 
 # Restrictive mask for production images.
 INSTALL_MASK="${INSTALL_MASK}
-  *.a *.la *.h *.hpp *.o
+  *.a *.la *.hpp *.o
   /etc/sandbox.d
   /usr/include
+  /usr/lib*/*/include
   /usr/lib/debug
   /usr/lib*/pkgconfig
   /usr/share/aclocal*
@@ -24,9 +25,4 @@ INSTALL_MASK="${INSTALL_MASK}
   /usr/bin/nmap
   /usr/share/ncat
   /usr/share/nmap
-"
-
-# These kernel paths are just noise without sources
-INSTALL_MASK="${INSTALL_MASK}
-  /usr/lib/modules/*/{build,source}
 "


### PR DESCRIPTION
But add /usr/lib*/*/include to prevent these headers from sneaking in.

This is being done to retain the kernel headers from
/lib/modules/$(uname -r)/build in production images.