### PR TITLE
flannel: Support multi-arch

### DIFF
--- a/app-admin/flannel/files/flanneld.service
+++ b/app-admin/flannel/files/flanneld.service
@@ -12,7 +12,7 @@ RestartSec=5
 Environment="TMPDIR=/var/tmp/"
 Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
 Environment="FLANNEL_VER={{flannel_ver}}"
-Environment="FLANNEL_IMG=quay.io/coreos/flannel"
+Environment="FLANNEL_IMG={{flannel_img}}"
 Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
 Environment="FLANNEL_ENV_FILE=/run/flannel/options.env"
 LimitNOFILE=40000

--- a/app-admin/flannel/flannel-9999.ebuild
+++ b/app-admin/flannel/flannel-9999.ebuild
@@ -23,7 +23,16 @@ RDEPEND="app-admin/sdnotify-proxy"
 S="$WORKDIR"
 
 src_install() {
-	sed "s/{{flannel_ver}}/${PV}/" "${FILESDIR}"/flanneld.service >"${T}"/flanneld.service
+	case ${ARCH} in
+		amd64) flannel_img="quay.io/coreos/flannel" ;;
+		arm64) flannel_img="quay.io/coreos/arm64-flannel" ;;
+		*) die "unsupported arch: ${ARCH}" ;;
+	esac
+
+	cp "${FILESDIR}"/flanneld.service "${T}"/flanneld.service
+	sed --in-place "s|{{flannel_ver}}|${PV}|" "${T}"/flanneld.service
+	sed --in-place "s|{{flannel_img}}|${flannel_img}|" "${T}"/flanneld.service
+
 	systemd_dounit "${T}"/flanneld.service
 
 	insinto /usr/lib/systemd/network


### PR DESCRIPTION
Set flannel docker image from ebuild based on build architecture.

I set this up to use ```quay.io/coreos/arm64-flannel``` for the arm64 image.  We could use ```flannel-arm64```, or something else.