### PR TITLE
profiles: do not wrap pkg-config as a legacy library config script

### DIFF
--- a/profiles/coreos/targets/generic/profile.bashrc
+++ b/profiles/coreos/targets/generic/profile.bashrc
@@ -18,6 +18,14 @@ cros_pre_pkg_preinst_wrap_old_config_scripts() {
 
 	local c w
 	for w in ${wrappers} ; do
+		# $CHOST-$CHOST-foo-config isn't helpful
+		if [[ ${w} == ${CHOST}-* ]]; then
+			continue
+		fi
+		# Skip anything that isn't a script, e.g. pkg-config
+		if ! head -n1 | egrep -q '^#!\s*/bin/(ba)?sh'; then
+			continue
+		fi
 		w="${wdir}/${CHOST}-${w}"
 		c="${CROS_ADDONS_TREE}/scripts/config_wrapper"
 		if [[ ! -e ${w} ]] ; then


### PR DESCRIPTION
This little bit of glue for handling old-style foo-config scripts was
assuming that anything in /usr/bin with a -config suffix was worth
wrapping. This is certainly not the case if the file in question is a
binary. This is most likely to cause confusion with pkg-config.