### PR TITLE
coreos/coreos-overlay: build selinux with coreutils

### DIFF
--- a/profiles/coreos/amd64/generic/package.use
+++ b/profiles/coreos/amd64/generic/package.use
@@ -4,3 +4,5 @@ sys-apps/dbus               selinux
 sys-apps/systemd            selinux
 sys-kernel/coreos-kernel    selinux
 
+# Enable SELinux for coreutils
+sys-apps/coreutils	    selinux


### PR DESCRIPTION
This fixes [#1059](https://github.com/coreos/bugs/issues/1059) allows the selinux context information to be displayed.
Now `ls -Z` shows the correct output. ex:

```
core@coreos_developer_qemu-1010-0-0-2 ~ $ id -Z
system_u:system_r:kernel_t:s0
```