### PR TITLE
raise low default (512) as of systemd 228+ on kernel 4.3+

### DIFF
--- a/app-emulation/docker/files/docker.service
+++ b/app-emulation/docker/files/docker.service
@@ -10,6 +10,7 @@ EnvironmentFile=-/run/flannel_docker_opts.env
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576
+TasksMax=1048576
 ExecStart=/usr/lib/coreos/dockerd daemon --host=fd:// $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
 
 [Install]


### PR DESCRIPTION
Applying upstream change https://github.com/docker/docker/pull/19391 to prevent `Resource temporarily unavailable` errors when running a large number of containers and/or containers with a large number of processes.