### PR TITLE
Include upstream patch to whitelist devices with SCSI_IDENT property

### DIFF
--- a/sys-fs/multipath-tools/files/multipath-tools-0.5.0-property-whitelist-SCSI_IDENT.patch
+++ b/sys-fs/multipath-tools/files/multipath-tools-0.5.0-property-whitelist-SCSI_IDENT.patch
@@ -1,0 +1,29 @@
+Origin: http://git.opensvc.com/gitweb.cgi?p=multipath-tools/.git;a=commit;h=d041591e42b69e2ff99d9cc5c1111c83ccde3207
+From: Hannes Reinecke <hare@suse.de>
+Date: Thu, 10 Apr 2014 10:21:52 +0000 (+0200)
+Subject: Use 'SCSI_IDENT_.*' as the default property whitelist
+X-Git-Url: http://git.opensvc.com/gitweb.cgi?p=multipath-tools%2F.git;a=commitdiff_plain;h=d041591e42b69e2ff99d9cc5c1111c83ccde3207
+
+Use 'SCSI_IDENT_.*' as the default property whitelist
+
+59-scsi-sg_utils.rules export the VPD pages as
+SCSI_IDENT_<association>_<type>.
+So whenever we have a SCSI_IDENT_* property we know it
+has come from VPD pages and we have a legit device.
+
+Signed-off-by: Hannes Reinecke <hare@suse.de>
+---
+
+diff --git a/libmultipath/blacklist.c b/libmultipath/blacklist.c
+index cea128c..30c5031 100644
+--- a/libmultipath/blacklist.c
++++ b/libmultipath/blacklist.c
+@@ -196,7 +196,7 @@ setup_default_blist (struct config * conf)
+ 	if (store_ble(conf->blist_devnode, str, ORIGIN_DEFAULT))
+ 		return 1;
+ 
+-	str = STRDUP("(ID_SCSI_VPD|ID_WWN)");
++	str = STRDUP("(SCSI_IDENT_.*|ID_WWN)");
+ 	if (!str)
+ 		return 1;
+ 	if (store_ble(conf->elist_property, str, ORIGIN_DEFAULT))

--- a/sys-fs/multipath-tools/multipath-tools-0.5.0-r2.ebuild
+++ b/sys-fs/multipath-tools/multipath-tools-0.5.0-r2.ebuild
@@ -25,6 +25,7 @@ DEPEND="${RDEPEND}
 src_prepare() {
 	epatch "${FILESDIR}"/${P}-makefile.patch
 	epatch "${FILESDIR}"/${P}-systemd-pkgconfig.patch
+	epatch "${FILESDIR}"/${P}-property-whitelist-SCSI_IDENT.patch
 	epatch_user
 }
 


### PR DESCRIPTION
Issue [#1236](https://github.com/coreos/bugs/issues/1236).