### PR TITLE
Disable nss utils build

### DIFF
--- a/profiles/coreos/targets/generic/package.use
+++ b/profiles/coreos/targets/generic/package.use
@@ -40,3 +40,6 @@ app-shells/bash -net vanilla
 
 # enable audit subsystem by default
 sys-kernel/coreos-kernel audit
+
+# disable nss utilities
+dev-libs/nss -utils


### PR DESCRIPTION
We don't need the nss utils in the product, so disable the flag.