### PR TITLE
profiles: accept jq ebuild with heap overflow fix

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -96,3 +96,8 @@ dev-util/checkbashisms
 
 # Older versions of sssd fail to build
 =sys-auth/sssd-1.13.1 ~amd64 ~arm64
+
+# heap overflow fix
+# https://bugs.gentoo.org/show_bug.cgi?id=580606
+=app-misc/jq-1.5-r2 ~amd64 ~arm64
+


### PR DESCRIPTION
depends on coreos/portage-stable#415