### PR TITLE
profiles: tell ccache to rewrite paths relative to $S

### DIFF
--- a/eclass/coreos-kernel.eclass
+++ b/eclass/coreos-kernel.eclass
@@ -113,8 +113,6 @@ kmake() {
 	if gcc-specs-pie; then
 		kernel_cflags="-nopie -fstack-check=no"
 	fi
-	# this can be removed once it is exported globally again
-	export CCACHE_BASEDIR="${S}"
 	emake "--directory=${S}/source" \
 		ARCH="${kernel_arch}" \
 		CROSS_COMPILE="${CHOST}-" \

--- a/profiles/coreos/base/profile.bashrc
+++ b/profiles/coreos/base/profile.bashrc
@@ -99,3 +99,10 @@ SYSROOT_WRAPPERS_BIN="/usr/lib/sysroot-wrappers/bin"
 if [[ "$PATH" != *"$SYSROOT_WRAPPERS_BIN"* ]]; then
     export PATH="$SYSROOT_WRAPPERS_BIN:$PATH"
 fi
+
+# Improve the chance that ccache is valid across versions by making all
+# paths under $S relative to $S, avoiding encoding the package version
+# contained in the path into __FILE__ expansions and debug info.
+if [[ -z "${CCACHE_BASEDIR}" ]] && [[ -d "${S}" ]]; then
+    export CCACHE_BASEDIR="${S}"
+fi


### PR DESCRIPTION
There are a number of ways the absolute path to a source file can make
it into the compiler output, some of which can prevent cached results
from being used when compiling related code in different locations.
The default source directory $S contains the package version so paths
need to be relative to it in order to work between package versions.

Previously attempted in 8259b77fc8eba8cfda54da565882283953bfd61a, should
be safe now that QEMU has been upgraded to 1.5. I've been using this
setting on my Gentoo machines and haven't found any other issues.
Also reverts commit 661ceb0fa114c499fa99b653bccb6d011c0d0b49.