### PR TITLE
google-*: import eutils, fix applying required patches

### DIFF
--- a/app-emulation/google-compute-daemon/google-compute-daemon-1.1.1-r4.ebuild
+++ b/app-emulation/google-compute-daemon/google-compute-daemon-1.1.1-r4.ebuild
@@ -3,6 +3,8 @@
 
 EAPI=5
 
+inherit eutils
+
 DESCRIPTION="Google Daemon for Compute Engine"
 HOMEPAGE="https://github.com/GoogleCloudPlatform/compute-image-packages"
 SRC_URI="https://github.com/GoogleCloudPlatform/compute-image-packages/releases/download/${PV}/google-daemon-${PV}.tar.gz"

--- a/app-emulation/google-startup-scripts/google-startup-scripts-1.1.1-r3.ebuild
+++ b/app-emulation/google-startup-scripts/google-startup-scripts-1.1.1-r3.ebuild
@@ -3,6 +3,8 @@
 
 EAPI=5
 
+inherit eutils
+
 DESCRIPTION="Google Startup Scripts for Compute Engine"
 HOMEPAGE="https://github.com/GoogleCloudPlatform/compute-image-packages"
 SRC_URI="https://github.com/GoogleCloudPlatform/compute-image-packages/releases/download/${PV}/${P}.tar.gz"


### PR DESCRIPTION
Broken back in 02c004e846, newly installed GCE images haven't worked
right ever since then. :(

Fixes https://github.com/coreos/bugs/issues/1285