### PR TITLE
profiles: stop disabling SHA512 password hashes in PAM

### DIFF
--- a/profiles/coreos/targets/generic/make.defaults
+++ b/profiles/coreos/targets/generic/make.defaults
@@ -3,7 +3,7 @@
 
 USE="cros-debug acpi usb symlink-usr cryptsetup policykit"
 USE="${USE} -cros_host -expat -cairo -X -man"
-USE="${USE} -acl -cracklib -gpm -python -sha512"
+USE="${USE} -acl -cracklib -gpm -python"
 USE="${USE} -fortran -abiword -perl -cups -poppler-data -nls"
 
 # Exclude documentation


### PR DESCRIPTION
Likely inherited from ChromeOS but even for them it is a completely
ridiculous flag to disable. We had SHA512 enabled pre-PAM since shadow
does not have this use flag so this restores previous behavior.