### PR TITLE
profiles: update protobuf from 1.5 to 1.6

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -34,7 +34,6 @@ dev-libs/dbus-glib ~arm64
 sys-block/parted ~arm64
 sys-fs/btrfs-progs ~arm64
 sys-apps/gptfdisk ~arm64
-dev-libs/protobuf ~arm64
 sys-apps/usbutils ~arm64
 net-misc/bridge-utils ~arm64
 net-libs/serf ~arm64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -101,3 +101,5 @@ dev-util/checkbashisms
 # https://bugs.gentoo.org/show_bug.cgi?id=580606
 =app-misc/jq-1.5-r2 ~amd64 ~arm64
 
+# Must use the same version across all architectures
+=dev-libs/protobuf-2.6.1-r3


### PR DESCRIPTION
The newer version is needed for arm64, and need the same version across
all architectures because the build host and target's version must match.