### PR TITLE
profile: begin explicitly masking packages for prod images

### DIFF
--- a/profiles/coreos/targets/generic/prod/README
+++ b/profiles/coreos/targets/generic/prod/README
@@ -4,4 +4,4 @@ Settings here must *ONLY* influence installing binary packages and never
 change build time settings like USE or CFLAGS because binary packages
 are shared between dev and prod, dev just includes more stuff.
 
-For example, INSTALL_MASK and package.provided are ok.
+For example INSTALL_MASK, package.mask, and package.provided are ok.

--- a/profiles/coreos/targets/generic/prod/package.mask
+++ b/profiles/coreos/targets/generic/prod/package.mask
@@ -1,0 +1,15 @@
+# Packages that we do not want to ship in production images. Masking these
+# is merely as a safe guard against pulling them in accidentally.
+
+# We don't want to support interpreted languages, changes/updates we make
+# would have a high risk of breaking users.
+dev-lang/perl
+# TODO dev-lang/python
+dev-lang/ruby
+
+# Since all SSL/TLS implementations are bad we minimize the number we ship.
+net-libs/gnutls
+
+# We do not configure/install grub like other distros so shipping the user
+# space tools would have limited utility.
+sys-boot/grub


### PR DESCRIPTION
This serves as a sanity check to avoid mistakes like pulling in python.