### PR TITLE
profiles/sdk: Build unstable qemu

### DIFF
--- a/profiles/coreos/amd64/sdk/package.accept_keywords
+++ b/profiles/coreos/amd64/sdk/package.accept_keywords
@@ -1,0 +1,3 @@
+# SDK keywords
+
+=app-emulation/qemu-2.6.0 ~amd64


### PR DESCRIPTION
qemu-2.6.0 includes a bug fix for arm64.  Without this the 4.6 kernel
will hang early in its boot with qemu-system-aarch64.

Depends on https://github.com/coreos/portage-stable/pull/437

@marineam Is this how we specify an unstable version (~amd64) for the SDK?