### PR TITLE
flannel: use rkt to launch flannel on amd64

### DIFF
--- a/app-admin/flannel/files/flanneld-rkt.service
+++ b/app-admin/flannel/files/flanneld-rkt.service
@@ -1,0 +1,38 @@
+[Unit]
+Description=Network fabric for containers
+Documentation=https://github.com/coreos/flannel
+After=etcd.service etcd2.service
+
+[Service]
+Type=notify
+Restart=always
+RestartSec=5
+Environment="TMPDIR=/var/tmp/"
+Environment="FLANNEL_VER={{flannel_ver}}"
+Environment="FLANNEL_IMG=quay.io/coreos/flannel"
+Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
+EnvironmentFile=-/run/flannel/options.env
+LimitNOFILE=40000
+LimitNPROC=1048576
+ExecStartPre=/sbin/modprobe ip_tables
+ExecStartPre=/usr/bin/mkdir -p /run/flannel
+ExecStartPre=/usr/bin/mkdir -p ${ETCD_SSL_DIR}
+
+ExecStart=/usr/bin/rkt run --net=host \
+   --stage1-path=/usr/lib/rkt/stage1-images/stage1-fly.aci \
+   --insecure-options=image \
+   --set-env=NOTIFY_SOCKET=/run/systemd/notify \
+   --inherit-env=true \
+   --volume runsystemd,kind=host,source=/run/systemd,readOnly=false \
+   --volume runflannel,kind=host,source=/run/flannel,readOnly=false \
+   --volume ssl,kind=host,source=${ETCD_SSL_DIR},readOnly=true \
+   --mount volume=runsystemd,target=/run/systemd \
+   --mount volume=runflannel,target=/run/flannel \
+   --mount volume=ssl,target=${ETCD_SSL_DIR} \
+   ${FLANNEL_IMG}:${FLANNEL_VER} \
+   -- --ip-masq=true
+
+ExecStopPost=/usr/bin/rkt gc --mark-only
+
+[Install]
+WantedBy=multi-user.target

--- a/app-admin/flannel/flannel-0.5.5-r2.ebuild
+++ b/app-admin/flannel/flannel-0.5.5-r2.ebuild
@@ -1,1 +1,31 @@
-flannel-9999.ebuild
+# Copyright (c) 2014 CoreOS, Inc.. All rights reserved.
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=4
+
+if [[ "${PV}" == 9999 ]]; then
+	KEYWORDS="~amd64 ~arm64"
+else
+	KEYWORDS="amd64 arm64"
+fi
+
+inherit systemd
+
+DESCRIPTION="flannel"
+HOMEPAGE="https://github.com/coreos/flannel"
+SRC_URI=""
+
+LICENSE="Apache-2.0"
+SLOT="0"
+IUSE=""
+
+RDEPEND="app-admin/sdnotify-proxy"
+S="$WORKDIR"
+
+src_install() {
+	sed "s/{{flannel_ver}}/${PV}/" "${FILESDIR}"/flanneld.service >"${T}"/flanneld.service
+	systemd_dounit "${T}"/flanneld.service
+
+	insinto /usr/lib/systemd/network
+	doins "${FILESDIR}"/50-flannel.network
+}

--- a/app-admin/flannel/flannel-0.5.5-r3.ebuild
+++ b/app-admin/flannel/flannel-0.5.5-r3.ebuild
@@ -1,0 +1,1 @@
+flannel-9999.ebuild

--- a/app-admin/flannel/flannel-9999.ebuild
+++ b/app-admin/flannel/flannel-9999.ebuild
@@ -4,9 +4,9 @@
 EAPI=4
 
 if [[ "${PV}" == 9999 ]]; then
-	KEYWORDS="~amd64 ~arm64"
+	KEYWORDS="~amd64"
 else
-	KEYWORDS="amd64 arm64"
+	KEYWORDS="amd64"
 fi
 
 inherit systemd
@@ -19,11 +19,11 @@ LICENSE="Apache-2.0"
 SLOT="0"
 IUSE=""
 
-RDEPEND="app-admin/sdnotify-proxy"
+RDEPEND="app-emulation/rkt"
 S="$WORKDIR"
 
 src_install() {
-	sed "s/{{flannel_ver}}/${PV}/" "${FILESDIR}"/flanneld.service >"${T}"/flanneld.service
+	sed "s/{{flannel_ver}}/${PV}/" "${FILESDIR}"/flanneld-rkt.service >"${T}"/flanneld.service
 	systemd_dounit "${T}"/flanneld.service
 
 	insinto /usr/lib/systemd/network


### PR DESCRIPTION
Launch flannel with rkt instead of an early instance of docker and remove early-docker