### PR TITLE
sys-auth/polkit: remove gobject-introspection from RDEPEND

### DIFF
--- a/profiles/coreos/targets/generic/prod/package.mask
+++ b/profiles/coreos/targets/generic/prod/package.mask
@@ -4,7 +4,7 @@
 # We don't want to support interpreted languages, changes/updates we make
 # would have a high risk of breaking users.
 dev-lang/perl
-# TODO dev-lang/python
+dev-lang/python
 dev-lang/ruby
 
 # Since all SSL/TLS implementations are bad we minimize the number we ship.

--- a/sys-auth/polkit/polkit-0.113-r2.ebuild
+++ b/sys-auth/polkit/polkit-0.113-r2.ebuild
@@ -18,7 +18,6 @@ CDEPEND="
 	dev-lang/spidermonkey:0/mozjs185[-debug]
 	>=dev-libs/glib-2.32:2
 	>=dev-libs/expat-2:=
-	introspection? ( >=dev-libs/gobject-introspection-1:= )
 	pam? (
 		sys-auth/pambase
 		virtual/pam
@@ -28,6 +27,7 @@ CDEPEND="
 DEPEND="${CDEPEND}
 	app-text/docbook-xml-dtd:4.1.2
 	app-text/docbook-xsl-stylesheets
+	introspection? ( >=dev-libs/gobject-introspection-1:= )
 	dev-libs/libxslt
 	dev-util/gtk-doc-am
 	dev-util/intltool


### PR DESCRIPTION
polkit's gobject library doesn't actually link against the library
provided by gobject-introspection so this appears to be a build-time
only dependency. Fixing this prunes python and lots of other packages:

```diff
--- developer-1068.0.0+2016-06-15-1524-a1/coreos_production_image_packages.txt	2016-06-15 15:27:59.353348324 -0700
+++ developer-1068.0.0+2016-06-15-1609-a1/coreos_production_image_packages.txt	2016-06-15 16:12:36.694523784 -0700
@@ -1,4 +1,3 @@
-app-admin/eselect-1.4.5::portage-stable
 app-admin/flannel-0.5.5-r2::coreos
 app-admin/fleet-0.11.7::coreos
 app-admin/kubelet-1.1.2_p0-r3::coreos
@@ -6,7 +5,6 @@
 app-admin/locksmith-0.3.4-r1::coreos
 app-admin/logrotate-3.9.1-r1::portage-stable
 app-admin/mayday-0.1.0-r1::coreos
-app-admin/python-updater-0.11::portage-stable
 app-admin/sdnotify-proxy-0.1.0-r2::coreos
 app-admin/setools-3.3.8-r7::coreos
 app-admin/sudo-1.8.15-r1::portage-stable
@@ -28,11 +26,9 @@
 app-emulation/rkt-1.8.0::coreos
 app-emulation/xenserver-pv-version-6.2.0::coreos
 app-emulation/xenstore-4.4.0-r1::coreos
-app-eselect/eselect-python-20111108::portage-stable
 app-misc/c_rehash-1.7-r1::portage-stable
 app-misc/ca-certificates-3.19.1::coreos
 app-misc/jq-1.5-r2::portage-stable
-app-misc/mime-types-9::portage-stable
 app-misc/pax-utils-1.0.3::portage-stable
 app-shells/bash-4.2_p53-r1::coreos
 coreos-base/coreos-0.0.1-r268::coreos
@@ -47,8 +43,6 @@
 dev-db/etcd-0.4.9-r2::coreos
 dev-db/etcd-2.3.2::coreos
 dev-db/sqlite-3.8.10.2::portage-stable
-dev-lang/python-2.7.9-r1::portage-stable
-dev-lang/python-exec-2.0.1-r1::portage-stable
 dev-lang/spidermonkey-1.8.5-r4::coreos
 dev-libs/cyrus-sasl-2.1.26-r9::coreos
 dev-libs/dbus-glib-0.102-r1::coreos
@@ -56,8 +50,6 @@
 dev-libs/elfutils-0.161::portage-stable
 dev-libs/expat-2.1.0-r5::portage-stable
 dev-libs/glib-2.44.1::portage-stable
-dev-libs/gobject-introspection-1.40.0-r1::portage-stable
-dev-libs/gobject-introspection-common-1.40.0::portage-stable
 dev-libs/libaio-0.3.110::portage-stable
 dev-libs/libassuan-2.2.1::portage-stable
 dev-libs/libbsd-0.8.2::portage-stable
@@ -80,9 +72,7 @@
 dev-libs/protobuf-2.6.1-r3::portage-stable
 dev-libs/pth-2.0.7-r3::portage-stable
 dev-libs/ustr-1.0.4-r6::coreos
-dev-python/pyxattr-0.5.2::portage-stable
 dev-util/bsdiff-4.3-r6::coreos
-dev-util/pkgconfig-0.28-r1::portage-stable
 dev-util/strace-4.9::portage-stable
 dev-vcs/git-2.7.3-r1::portage-stable
 net-analyzer/nmap-6.47-r1::portage-stable
@@ -120,14 +110,12 @@
 sys-apps/dbus-1.8.16-r2::coreos
 sys-apps/diffutils-3.3::portage-stable
 sys-apps/ethtool-3.18::portage-stable
-sys-apps/file-5.22::portage-stable
 sys-apps/findutils-4.4.2-r1::portage-stable
 sys-apps/gawk-4.0.2::portage-stable
 sys-apps/gentoo-functions-0.10::portage-stable
 sys-apps/gptfdisk-0.8.10::portage-stable
 sys-apps/grep-2.21-r1::portage-stable
 sys-apps/hwids-20150717-r1::portage-stable
-sys-apps/install-xattr-0.4::portage-stable
 sys-apps/iproute2-3.19.0::coreos
 sys-apps/kexec-tools-2.0.4-r1::coreos
 sys-apps/keyutils-1.5.9-r2::coreos
@@ -137,10 +125,8 @@
 sys-apps/net-tools-1.60_p20130513023548::portage-stable
 sys-apps/pciutils-3.3.1::portage-stable
 sys-apps/policycoreutils-2.4-r2::coreos
-sys-apps/portage-2.2.28::coreos
 sys-apps/rng-tools-5::portage-stable
 sys-apps/rootdev-0.0.1-r11::coreos
-sys-apps/sandbox-2.6-r1::portage-stable
 sys-apps/sed-4.2.1-r1::portage-stable
 sys-apps/seismograph-2.1.0::coreos
 sys-apps/shadow-4.1.5.1-r5::coreos
@@ -149,7 +135,7 @@
 sys-apps/util-linux-2.27.1::portage-stable
 sys-apps/which-2.20-r1::portage-stable
 sys-auth/pambase-20120417-r99::coreos
-sys-auth/polkit-0.113-r1::coreos
+sys-auth/polkit-0.113-r2::coreos
 sys-auth/realmd-0.16.2::coreos
 sys-auth/sssd-1.13.1::coreos
 sys-block/open-iscsi-2.0.873-r2::coreos
@@ -168,7 +154,6 @@
 sys-kernel/coreos-firmware-20160331::coreos
 sys-kernel/coreos-kernel-4.6.0-r1::coreos
 sys-libs/e2fsprogs-libs-1.42.13::portage-stable
-sys-libs/gdbm-1.11::portage-stable
 sys-libs/glibc-2.21-r3::coreos
 sys-libs/ldb-1.1.26-r1::coreos
 sys-libs/libcap-2.24-r2::portage-stable
@@ -198,6 +183,5 @@
 virtual/libudev-208::portage-stable
 virtual/libusb-1-r1::portage-stable
 virtual/pam-0-r1::portage-stable
-virtual/pkgconfig-0-r1::portage-stable
 virtual/shadow-0::portage-stable
 virtual/udev-208-r2::portage-stable
```