### PR TITLE
sys-auth/polkit: remove gobject-introspection from RDEPEND for 1068

### DIFF
--- a/profiles/coreos/targets/generic/prod/README
+++ b/profiles/coreos/targets/generic/prod/README
@@ -4,4 +4,4 @@ Settings here must *ONLY* influence installing binary packages and never
 change build time settings like USE or CFLAGS because binary packages
 are shared between dev and prod, dev just includes more stuff.
 
-For example, INSTALL_MASK and package.provided are ok.
+For example INSTALL_MASK, package.mask, and package.provided are ok.

--- a/profiles/coreos/targets/generic/prod/package.mask
+++ b/profiles/coreos/targets/generic/prod/package.mask
@@ -4,7 +4,7 @@
 # We don't want to support interpreted languages, changes/updates we make
 # would have a high risk of breaking users.
 dev-lang/perl
-# TODO dev-lang/python
+dev-lang/python
 dev-lang/ruby
 
 # Since all SSL/TLS implementations are bad we minimize the number we ship.

--- a/profiles/coreos/targets/generic/prod/package.mask
+++ b/profiles/coreos/targets/generic/prod/package.mask
@@ -1,0 +1,15 @@
+# Packages that we do not want to ship in production images. Masking these
+# is merely as a safe guard against pulling them in accidentally.
+
+# We don't want to support interpreted languages, changes/updates we make
+# would have a high risk of breaking users.
+dev-lang/perl
+# TODO dev-lang/python
+dev-lang/ruby
+
+# Since all SSL/TLS implementations are bad we minimize the number we ship.
+net-libs/gnutls
+
+# We do not configure/install grub like other distros so shipping the user
+# space tools would have limited utility.
+sys-boot/grub

--- a/sys-auth/polkit/polkit-0.113-r2.ebuild
+++ b/sys-auth/polkit/polkit-0.113-r2.ebuild
@@ -18,7 +18,6 @@ CDEPEND="
 	dev-lang/spidermonkey:0/mozjs185[-debug]
 	>=dev-libs/glib-2.32:2
 	>=dev-libs/expat-2:=
-	introspection? ( >=dev-libs/gobject-introspection-1:= )
 	pam? (
 		sys-auth/pambase
 		virtual/pam
@@ -28,6 +27,7 @@ CDEPEND="
 DEPEND="${CDEPEND}
 	app-text/docbook-xml-dtd:4.1.2
 	app-text/docbook-xsl-stylesheets
+	introspection? ( >=dev-libs/gobject-introspection-1:= )
 	dev-libs/libxslt
 	dev-util/gtk-doc-am
 	dev-util/intltool


### PR DESCRIPTION
Backport https://github.com/coreos/coreos-overlay/pull/2011 and https://github.com/coreos/coreos-overlay/pull/1999