### PR TITLE
profiles/arm64: Update nmap

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -27,7 +27,7 @@ dev-libs/libevent ~arm64
 net-misc/ntp ~arm64
 
 net-libs/libpcap ~arm64
-=net-analyzer/nmap-6.49_beta2 **
+=net-analyzer/nmap-7.12 ~arm64
 
 app-crypt/pinentry ~arm64
 net-analyzer/tcpdump ~arm64


### PR DESCRIPTION
Sync nmap in package.accept.keywords to https://github.com/coreos/portage-stable/pull/452.
Fixes arm64 build breakage.

cc: @mischief