### PR TITLE
sys-auth/sssd: Enable Kerberos support

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -68,7 +68,7 @@ net-dns/bind-tools gssapi
 dev-libs/cyrus-sasl kerberos -berkdb -gdbm
 
 # don't build manpages for sssd
-sys-auth/sssd -manpages -python
+sys-auth/sssd -manpages -python kerberos gssapi
 
 # needed for realmd build
 sys-auth/polkit introspection

--- a/sys-auth/sssd/sssd-1.13.1-r1.ebuild
+++ b/sys-auth/sssd/sssd-1.13.1-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="http://fedorahosted.org/released/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86"
+KEYWORDS="amd64 arm64 ~hppa ~ppc ~ppc64 ~x86"
 IUSE="acl augeas autofs +locator netlink nfsv4 nls +manpages python samba selinux sudo ssh test"
 
 COMMON_DEP="


### PR DESCRIPTION
Add the appropriate flags for building with Kerberos support and bump the version