### PR TITLE
Fix equery for e2fsprogs

### DIFF
--- a/sys-fs/e2fsprogs/metadata.xml
+++ b/sys-fs/e2fsprogs/metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+<maintainer type="project">
+	<email>base-system@gentoo.org</email>
+	<name>Gentoo Base System</name>
+</maintainer>
+<use>
+	<flag name='fuse'>Build fuse2fs, a FUSE file system client for ext2/ext3/ext4 file systems</flag>
+</use>
+<upstream>
+	<remote-id type="cpe">cpe:/a:ext2_filesystems_utilities:e2fsprogs</remote-id>
+	<remote-id type="sourceforge">e2fsprogs</remote-id>
+</upstream>
+</pkgmetadata>


### PR DESCRIPTION
Revert the removal of metadata.xml from commit
cc7f579db2bb8e12011b884623689922bf245998.

Fixes equery errors like these:

  !!! Package sys-fs/e2fsprogs-1.42.13-r1 is missing metadata.xml

cc: @ajeddeloh