### PR TITLE
profiles: mask recent procps in amd64 images

### DIFF
--- a/profiles/coreos/amd64/generic/package.mask
+++ b/profiles/coreos/amd64/generic/package.mask
@@ -1,0 +1,3 @@
+# the OEM package app-emulation/open-vm-tools has been linking against
+# procps but recent versions have changed the soname. Mask until we fix. :(
+>=sys-process/procps-3.3.10


### PR DESCRIPTION
We need to sort out OEM updating asap...