### PR TITLE
Make undefined NSS lookups succeed when SSSD isn't running

### DIFF
--- a/sys-auth/sssd/sssd-1.13.1-r2.ebuild
+++ b/sys-auth/sssd/sssd-1.13.1-r2.ebuild
@@ -105,6 +105,7 @@ multilib_src_configure() {
 		--with-unicode-lib="glib2"
 		--disable-rpath
 		--disable-silent-rules
+		--enable-sss-default-nss-plugin
 		--sbindir=/usr/sbin
 		$(multilib_native_use_with samba)
 		$(multilib_native_use_enable acl cifs-idmap-plugin)


### PR DESCRIPTION
This fixes coreos/bugs#1466.