### PR TITLE
profiles/coreos: accept net-misc/curl-7.50.1

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -90,9 +90,8 @@ dev-util/checkbashisms
 # use this wget to get slotted openssl dep.
 =net-misc/wget-1.17.1-r1 ~amd64 ~arm64
 
-# avoid curl vulnerability 38/39
 # https://curl.haxx.se/docs/security.html
-=net-misc/curl-7.47.1 ~amd64 ~arm64
+=net-misc/curl-7.50.1 ~amd64 ~arm64
 
 # Older versions of sssd fail to build
 =sys-auth/sssd-1.13.1 ~amd64 ~arm64


### PR DESCRIPTION
depends on https://github.com/coreos/portage-stable/pull/466