### PR TITLE
eclass: omit dwarf symbol table from go binaries

### DIFF
--- a/eclass/coreos-go.eclass
+++ b/eclass/coreos-go.eclass
@@ -43,7 +43,7 @@ go_build() {
 
 	go build -v \
 		-p "$(makeopts_jobs)" \
-		-ldflags "${GO_LDFLAGS} -extldflags '${LDFLAGS}'" \
+		-ldflags "${GO_LDFLAGS} -w -extldflags '${LDFLAGS}'" \
 		-o "${GOBIN}/${binary_name}" \
 		"${package_name}"
 


### PR DESCRIPTION
This saves a couple kilobytes from each binary. Not much, but we'll take
it.