### PR TITLE
sys-auth/sssd: Enable SSH helpers

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -68,7 +68,7 @@ net-dns/bind-tools gssapi
 dev-libs/cyrus-sasl kerberos -berkdb -gdbm
 
 # don't build manpages for sssd
-sys-auth/sssd -manpages -python kerberos gssapi
+sys-auth/sssd -manpages -python kerberos gssapi ssh
 
 # needed for realmd build
 sys-auth/polkit introspection


### PR DESCRIPTION
Build the SSH-related helpers for sssd so authorized_keys can be stored
in LDAP.