### PR TITLE
coreos-base/oem-qemu: add qemu oem definition

### DIFF
--- a/coreos-base/oem-qemu/files/grub.cfg
+++ b/coreos-base/oem-qemu/files/grub.cfg
@@ -1,0 +1,3 @@
+# CoreOS GRUB settings
+
+set oem_id="qemu"

--- a/coreos-base/oem-qemu/oem-qemu-0.0.1.ebuild
+++ b/coreos-base/oem-qemu/oem-qemu-0.0.1.ebuild
@@ -1,0 +1,21 @@
+# Copyright (c) 2016 CoreOS, Inc.. All rights reserved.
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="OEM suite for QEMU"
+HOMEPAGE=""
+SRC_URI=""
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="amd64 arm64"
+IUSE=""
+
+# no source directory
+S="${WORKDIR}"
+
+src_install() {
+	insinto "/usr/share/oem"
+	doins "${FILESDIR}/grub.cfg"
+}


### PR DESCRIPTION
This is needed so that CoreOS identifies that it is running on QEMU.