### PR TITLE
Revert "app-emulation/rkt: Remove go environment settings"

### DIFF
--- a/app-emulation/rkt/rkt-9999.ebuild
+++ b/app-emulation/rkt/rkt-9999.ebuild
@@ -119,6 +119,12 @@ src_configure() {
 		append-ldflags -nopie
 	fi
 
+	export CC=$(tc-getCC)
+	export CGO_ENABLED=1
+	export CGO_CFLAGS="${CFLAGS}"
+	export CGO_CPPFLAGS="${CPPFLAGS}"
+	export CGO_CXXFLAGS="${CXXFLAGS}"
+	export CGO_LDFLAGS="${LDFLAGS}"
 	export BUILDDIR
 	export V=1
 


### PR DESCRIPTION
After this we're no longer passing -nopie to the linker, rkt is
ending up with a TEXTREL section and SELinux is blocking execution.
Revert until it's fixed.