### PR TITLE
app-emulation/runc: patch out installing deps in makefile

### DIFF
--- a/app-emulation/runc/files/0001-Makefile-do-not-install-dependencies-of-target.patch
+++ b/app-emulation/runc/files/0001-Makefile-do-not-install-dependencies-of-target.patch
@@ -1,0 +1,27 @@
+From 7a09c7817af44c87772c728655b71c6cfc9d1bc9 Mon Sep 17 00:00:00 2001
+From: Nick Owens <mischief@offblast.org>
+Date: Wed, 24 Aug 2016 19:34:42 -0700
+Subject: [PATCH] Makefile: do not install dependencies of target
+
+in order to install one must have permission to write to GOROOT which is
+not the case in the CoreOS sdk.
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 0852c71..283aceb 100644
+--- a/Makefile
++++ b/Makefile
+@@ -23,7 +23,7 @@ MAN_INSTALL_PATH := ${PREFIX}/share/man/man8/
+ VERSION := ${shell cat ./VERSION}
+ 
+ all: $(RUNC_LINK)
+-	go build -i -ldflags "-X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -tags "$(BUILDTAGS)" -o runc .
++	go build -ldflags "-X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -tags "$(BUILDTAGS)" -o runc .
+ 
+ static: $(RUNC_LINK)
+ 	CGO_ENABLED=1 go build -i -tags "$(BUILDTAGS) cgo static_build" -ldflags "-w -extldflags -static -X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -o runc .
+-- 
+2.9.3
+

--- a/app-emulation/runc/runc-1.0.0_rc1_p20160615-r1.ebuild
+++ b/app-emulation/runc/runc-1.0.0_rc1_p20160615-r1.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 "
 
 src_prepare() {
-	eapply_user
+	epatch "${FILESDIR}/0001-Makefile-do-not-install-dependencies-of-target.patch"
 }
 
 src_compile() {


### PR DESCRIPTION
runc invokes go build -i, which installs dependencies to GOROOT. the
build is run without privilege to write there, so it fails.