### PR TITLE
multilib-strict and stricter fixes

### DIFF
--- a/app-emulation/open-vm-tools/open-vm-tools-9.10.0-r1.ebuild
+++ b/app-emulation/open-vm-tools/open-vm-tools-9.10.0-r1.ebuild
@@ -64,10 +64,10 @@ src_configure() {
 	append-ldflags "-Wl,-rpath,${oemlib}"
 
 	# libdnet is installed to /usr/share/oem
-	export CUSTOM_DNET_CPPFLAGS="-I${SYSROOT}${oeminc}"
-	export CUSTOM_DNET_LIBS="-L${SYSROOT}${oemlib}"
-	export CUSTOM_MSPACK_CPPFLAGS="-I${SYSROOT}${oeminc}"
-	export CUSTOM_MSPACK_LIBS="-L${SYSROOT}${oemlib}"
+	export CUSTOM_DNET_CPPFLAGS="-I=${oeminc}"
+	export CUSTOM_DNET_LIBS="-L=${oemlib}"
+	export CUSTOM_MSPACK_CPPFLAGS="-I=${oeminc}"
+	export CUSTOM_MSPACK_LIBS="-L=${oemlib}"
 
 	# >=sys-process/procps-3.3.2 not handled by configure
 	export CUSTOM_PROCPS_NAME=procps

--- a/dev-lang/go-bootstrap/go-bootstrap-1.5.3.ebuild
+++ b/dev-lang/go-bootstrap/go-bootstrap-1.5.3.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=6
 
-inherit eutils toolchain-funcs
+inherit coreos-go-utils
 
 BOOTSTRAP_DIST="https://dev.gentoo.org/~williamh/dist"
 SRC_URI="amd64? ( ${BOOTSTRAP_DIST}/go-linux-amd64-bootstrap.tbz )
@@ -23,59 +23,25 @@ IUSE=""
 DEPEND=""
 RDEPEND=""
 
-# The go tools should not cause the multilib-strict check to fail.
-QA_MULTILIB_PATHS="usr/lib/go-bootstrap/pkg/tool/.*/.*"
+# Disable all QA_* checks since these are pre-built binaries.
+QA_PREBUILT="usr/lib/go-bootstrap/*"
+
+# Test data is never executed so don't check link dependencies.
+REQUIRES_EXCLUDE="/usr/lib/go-bootstrap/src/debug/elf/testdata/*"
 
 # The go language uses *.a files which are _NOT_ libraries and should not be
-# stripped.
-STRIP_MASK="/usr/lib/go-bootstrap/pkg/linux*/*.a
-	/usr/lib/go-bootstrap/src/debug/elf/testdata/*
-	/usr/lib/go-bootstrap/src/debug/dwarf/testdata/*
-	/usr/lib/go-bootstrap/src/runtime/race/*.syso"
-
-go_arch()
-{
-	# By chance most portage arch names match Go
-	local portage_arch=$(tc-arch $@)
-	case "${portage_arch}" in
-		x86)	echo 386;;
-		x64-*)	echo amd64;;
-		*)		echo "${portage_arch}";;
-	esac
-}
-
-go_os()
-{
-	case "${1:-${CHOST}}" in
-		*-linux*)	echo linux;;
-		*)
-			die "unknown GOOS for ${1:-${CHOST}}"
-			;;
-	esac
-}
+# stripped. The test data objects should also be left alone and unstripped.
+STRIP_MASK="*.a /usr/lib/go-bootstrap/src/*"
 
 S="${WORKDIR}"/go-$(go_os)-$(go_arch)-bootstrap
 
-src_install()
-{
+src_install() {
 	dodir /usr/lib/go-bootstrap
 	exeinto /usr/lib/go-bootstrap/bin
 	doexe bin/*
+
+	insopts -m0644 -p # preserve timestamps
 	insinto /usr/lib/go-bootstrap
 	doins -r lib pkg src
 	fperms -R +x /usr/lib/go-bootstrap/pkg/tool
 }
-
-pkg_postinst()
-{
-	# If the go tool sees a package file timestamped older than a dependancy it
-	# will rebuild that file.  So, in order to stop go from rebuilding lots of
-	# packages for every build we need to fix the timestamps.  The compiler and
-	# linker are also checked - so we need to fix them too.
-	ebegin "fixing timestamps to avoid unnecessary rebuilds"
-	tref="usr/lib/go-bootstrap/pkg/*/runtime.a"
-	find "${EROOT}"usr/lib/go-bootstrap -type f \
-		-exec touch -r "${EROOT}"${tref} {} \;
-	eend $?
-}
-

--- a/eclass/coreos-kernel.eclass
+++ b/eclass/coreos-kernel.eclass
@@ -25,6 +25,9 @@ DEPEND="=sys-kernel/coreos-sources-${COREOS_SOURCE_VERSION}"
 # Do not analyze or strip installed files
 RESTRICT="binchecks strip"
 
+# The build tools are OK and shouldn't trip up multilib-strict.
+QA_MULTILIB_PATHS="usr/lib/modules/.*/build/scripts/.*"
+
 # Use source installed by coreos-sources
 KERNEL_DIR="${SYSROOT}/usr/src/${COREOS_SOURCE_NAME}"
 

--- a/sys-auth/realmd/realmd-0.16.2.ebuild
+++ b/sys-auth/realmd/realmd-0.16.2.ebuild
@@ -25,6 +25,9 @@ DEPEND="sys-auth/polkit[introspection]
 	systemd? ( sys-apps/systemd )"
 RDEPEND="${DEPEND}"
 
+# The daemon is installed to a private dir under /usr/lib, similar to systemd.
+QA_MULTILIB_PATHS="usr/lib/realmd/realmd"
+
 src_prepare() {
 	sed -e '/gentoo-release/s/dnl/ /g' -i configure.ac
 


### PR DESCRIPTION
I'm tinkering w/ performing builds that make a number of checks portage performs fatal. This would avoid things like missing TEXTREL issues. Before that can happen here are a few minor things to fix up.