### PR TITLE
sys-libs/ncurses: fix some compiler warnings

### DIFF
--- a/sys-libs/ncurses/files/ncurses-5.9-compiler-warnings.patch
+++ b/sys-libs/ncurses/files/ncurses-5.9-compiler-warnings.patch
@@ -1,0 +1,177 @@
+From fed65dd4e3fddb3c8f568a77b66c8b97c6757ad0 Mon Sep 17 00:00:00 2001
+From: "Thomas E. Dickey" <dickey@invisible-island.net>
+Date: Sun, 13 Oct 2013 00:58:13 +0000
+Subject: [PATCH] ncurses 5.9 - patch 20131012 - compiler warnings
+
++ fix a few compiler warnings in progs and test.
+---
+ progs/tset.c   | 73 +++++++++++++++++++++++++++++++++-------------------------
+ test/ncurses.c |  2 +-
+ 2 files changed, 42 insertions(+), 33 deletions(-)
+
+diff --git a/progs/tset.c b/progs/tset.c
+index 084e41d..8bedd14 100644
+--- a/progs/tset.c
++++ b/progs/tset.c
+@@ -788,14 +788,14 @@ reset_mode(void)
+     mode.c_cc[VWERASE] = CHK(mode.c_cc[VWERASE], CWERASE);
+ #endif
+ 
+-    mode.c_iflag &= ~(IGNBRK | PARMRK | INPCK | ISTRIP | INLCR | IGNCR
++    mode.c_iflag &= ~((unsigned) (IGNBRK | PARMRK | INPCK | ISTRIP | INLCR | IGNCR
+ #ifdef IUCLC
+-		      | IUCLC
++				  | IUCLC
+ #endif
+ #ifdef IXANY
+-		      | IXANY
++				  | IXANY
+ #endif
+-		      | IXOFF);
++				  | IXOFF));
+ 
+     mode.c_iflag |= (BRKINT | IGNPAR | ICRNL | IXON
+ #ifdef IMAXBEL
+@@ -803,44 +803,44 @@ reset_mode(void)
+ #endif
+ 	);
+ 
+-    mode.c_oflag &= ~(0
++    mode.c_oflag &= ~((unsigned) (0
+ #ifdef OLCUC
+-		      | OLCUC
++				  | OLCUC
+ #endif
+ #ifdef OCRNL
+-		      | OCRNL
++				  | OCRNL
+ #endif
+ #ifdef ONOCR
+-		      | ONOCR
++				  | ONOCR
+ #endif
+ #ifdef ONLRET
+-		      | ONLRET
++				  | ONLRET
+ #endif
+ #ifdef OFILL
+-		      | OFILL
++				  | OFILL
+ #endif
+ #ifdef OFDEL
+-		      | OFDEL
++				  | OFDEL
+ #endif
+ #ifdef NLDLY
+-		      | NLDLY
++				  | NLDLY
+ #endif
+ #ifdef CRDLY
+-		      | CRDLY
++				  | CRDLY
+ #endif
+ #ifdef TABDLY
+-		      | TABDLY
++				  | TABDLY
+ #endif
+ #ifdef BSDLY
+-		      | BSDLY
++				  | BSDLY
+ #endif
+ #ifdef VTDLY
+-		      | VTDLY
++				  | VTDLY
+ #endif
+ #ifdef FFDLY
+-		      | FFDLY
++				  | FFDLY
+ #endif
+-	);
++		      ));
+ 
+     mode.c_oflag |= (OPOST
+ #ifdef ONLCR
+@@ -848,19 +848,19 @@ reset_mode(void)
+ #endif
+ 	);
+ 
+-    mode.c_cflag &= ~(CSIZE | CSTOPB | PARENB | PARODD | CLOCAL);
++    mode.c_cflag &= ~((unsigned) (CSIZE | CSTOPB | PARENB | PARODD | CLOCAL));
+     mode.c_cflag |= (CS8 | CREAD);
+-    mode.c_lflag &= ~(ECHONL | NOFLSH
++    mode.c_lflag &= ~((unsigned) (ECHONL | NOFLSH
+ #ifdef TOSTOP
+-		      | TOSTOP
++				  | TOSTOP
+ #endif
+ #ifdef ECHOPTR
+-		      | ECHOPRT
++				  | ECHOPRT
+ #endif
+ #ifdef XCASE
+-		      | XCASE
++				  | XCASE
+ #endif
+-	);
++		      ));
+ 
+     mode.c_lflag |= (ISIG | ICANON | ECHO | ECHOE | ECHOK
+ #ifdef ECHOCTL
+@@ -907,14 +907,23 @@ static void
+ set_control_chars(void)
+ {
+ #ifdef TERMIOS
+-    if (DISABLED(mode.c_cc[VERASE]) || terasechar >= 0)
+-	mode.c_cc[VERASE] = (terasechar >= 0) ? terasechar : default_erase();
++    if (DISABLED(mode.c_cc[VERASE]) || terasechar >= 0) {
++	mode.c_cc[VERASE] = UChar((terasechar >= 0)
++				  ? terasechar
++				  : default_erase());
++    }
+ 
+-    if (DISABLED(mode.c_cc[VINTR]) || intrchar >= 0)
+-	mode.c_cc[VINTR] = (intrchar >= 0) ? intrchar : CINTR;
++    if (DISABLED(mode.c_cc[VINTR]) || intrchar >= 0) {
++	mode.c_cc[VINTR] = UChar((intrchar >= 0)
++				 ? intrchar
++				 : CINTR);
++    }
+ 
+-    if (DISABLED(mode.c_cc[VKILL]) || tkillchar >= 0)
+-	mode.c_cc[VKILL] = (tkillchar >= 0) ? tkillchar : CKILL;
++    if (DISABLED(mode.c_cc[VKILL]) || tkillchar >= 0) {
++	mode.c_cc[VKILL] = UChar((tkillchar >= 0)
++				 ? tkillchar
++				 : CKILL);
++    }
+ #endif
+ }
+ 
+@@ -970,9 +979,9 @@ set_conversions(void)
+     if (newline != (char *) 0 && newline[0] == '\n' && !newline[1]) {
+ 	/* Newline, not linefeed. */
+ #ifdef ONLCR
+-	mode.c_oflag &= ~ONLCR;
++	mode.c_oflag &= ~((unsigned) ONLCR);
+ #endif
+-	mode.c_iflag &= ~ICRNL;
++	mode.c_iflag &= ~((unsigned) ICRNL);
+     }
+ #ifdef __OBSOLETE__
+     if (tgetflag("HD"))		/* Half duplex. */
+diff --git a/test/ncurses.c b/test/ncurses.c
+index 5a422cf..75063a7 100644
+--- a/test/ncurses.c
++++ b/test/ncurses.c
+@@ -1678,7 +1678,7 @@ wide_show_attr(int row, int skip, bool arrow, chtype attr, short pair, const cha
+ 	attr_t old_attr;
+ 	short old_pair;
+ 
+-	(void) attr_get(&old_attr, &old_pair, 0);
++	(void) (attr_get)(&old_attr, &old_pair, 0);
+ 	(void) attr_set(attr, pair, 0);
+ 	addwstr(wide_attr_test_string);
+ 	(void) attr_set(old_attr, old_pair, 0);
+-- 
+2.7.3
+

--- a/sys-libs/ncurses/ncurses-5.9-r7.ebuild
+++ b/sys-libs/ncurses/ncurses-5.9-r7.ebuild
@@ -50,6 +50,7 @@ src_prepare() {
 	epatch "${FILESDIR}"/${PN}-5.9-pkg-config.patch
 	epatch "${FILESDIR}"/${P}-no-I-usr-include.patch #522586
 	epatch "${FILESDIR}"/${P}-gcc-5.patch #545114
+	epatch "${FILESDIR}"/${P}-compiler-warnings.patch
 }
 
 src_configure() {


### PR DESCRIPTION
From http://ncurses.scripts.mit.edu/?p=ncurses.git;a=commit;h=73ab536b636227eed291dad213ca88c93d422fb8

The important part is the tiny change to use the attr_get function
instead of the macro fixing:

    test/ncurses.c:1681:29: warning: the comparison will always evaluate
    as ‘true’ for the address of ‘old_attr’ will never be NULL [-Waddress]

which causes portage to abort with FEATURES=stricter