### PR TITLE
profiles: include libc locale data

### DIFF
--- a/profiles/coreos/targets/generic/make.defaults
+++ b/profiles/coreos/targets/generic/make.defaults
@@ -11,12 +11,10 @@ FEATURES="nodoc noinfo noman"
 
 # Exclude even more documentaiton
 # Remove bash-completion files as we don't install bash-completion.
-# Remove alternate locales, we only need the standard LANG=C
+# Remove locale LC_MESSAGES files.
 INSTALL_MASK="${INSTALL_MASK}
-  /etc/locale.gen
   /usr/share/bash-completion
   /usr/share/gtk-doc
-  /usr/share/i18n
   /usr/share/locale
   /usr/share/zsh
   /var/db/Makefile


### PR DESCRIPTION
This data can be later removed by build_image once it has run localedef
to generate the C.UTF-8 locale. When cross-compiling the glibc ebuild
won't run localedef so it is up to build image to handle.