### PR TITLE
kubelet-wrapper: delete previous pods on launch

### DIFF
--- a/app-admin/kubelet-wrapper/files/kubelet-wrapper
+++ b/app-admin/kubelet-wrapper/files/kubelet-wrapper
@@ -51,9 +51,16 @@ if [[ "${KUBELET_IMAGE%%/*}" == "quay.io" ]]; then
 	RKT_RUN_ARGS="${RKT_RUN_ARGS} --trust-keys-from-https"
 fi
 
+UUID_FILE="/var/lib/kubelet-wrapper/last-uuid"
+
+if [ -f "${UUID_FILE}" ]; then
+  /usr/bin/rkt rm --uuid-file="${UUID_FILE}" &>/dev/null || true
+fi
+
 mkdir --parents /etc/kubernetes
 mkdir --parents /var/lib/docker
 mkdir --parents /var/lib/kubelet
+mkdir --parents /var/lib/kubelet-wrapper
 mkdir --parents /run/kubelet
 
 RKT="${RKT:-/usr/bin/rkt}"
@@ -62,6 +69,7 @@ KUBELET_IMAGE_ARGS=${KUBELET_IMAGE_ARGS:---exec=/kubelet}
 set -x
 exec ${RKT} ${RKT_GLOBAL_ARGS} \
 	run ${RKT_RUN_ARGS} \
+	--uuid-file-save "${UUID_FILE}" \
 	--volume etc-kubernetes,kind=host,source=/etc/kubernetes,readOnly=false \
 	--volume etc-ssl-certs,kind=host,source=/etc/ssl/certs,readOnly=true \
 	--volume usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
@@ -80,3 +88,5 @@ exec ${RKT} ${RKT_GLOBAL_ARGS} \
 	${KUBELET_IMAGE} \
 		${KUBELET_IMAGE_ARGS} \
 		-- "$@"
+
+# vim: noexpandtab


### PR DESCRIPTION
Works around https://github.com/coreos/bugs/issues/1612

Perhaps it would be better to save the uuid in something like `/var/run/kubelet_wrapper.uuid` instead to sorta match pid files.

cc @jonboulle  @pbx0 
