### PR TITLE
app-emulation/{containerd,docker}: separately managed containerd unit

### DIFF
--- a/app-emulation/containerd/containerd-0.2.3-r1.ebuild
+++ b/app-emulation/containerd/containerd-0.2.3-r1.ebuild
@@ -1,0 +1,1 @@
+containerd-9999.ebuild

--- a/app-emulation/containerd/containerd-9999.ebuild
+++ b/app-emulation/containerd/containerd-9999.ebuild
@@ -19,7 +19,7 @@ else
 	inherit vcs-snapshot
 fi
 
-inherit coreos-go
+inherit coreos-go systemd
 
 DESCRIPTION="A daemon to control runC"
 HOMEPAGE="https://containerd.tools"
@@ -39,4 +39,6 @@ src_compile() {
 
 src_install() {
 	dobin bin/containerd* bin/ctr
+
+	systemd_dounit "${FILESDIR}/containerd.service"
 }

--- a/app-emulation/containerd/files/containerd.service
+++ b/app-emulation/containerd/files/containerd.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Containerd Container Daemon
+Documentation=http://github.com/docker/containerd
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/containerd --listen unix:///var/run/docker/libcontainerd/docker-containerd.sock --shim /usr/bin/containerd-shim --state-dir /var/run/docker/libcontainerd/containerd --runtime /usr/bin/runc
+
+# (lack of) limits from the upstream docker service unit
+LimitNOFILE=1048576
+LimitNPROC=infinity
+LimitCORE=infinity
+TasksMax=infinity
+
+# set delegate yes so that systemd does not reset the cgroups of containers
+Delegate=yes
+
+[Install]
+WantedBy=multi-user.target early-docker.target

--- a/app-emulation/docker/files/docker.service
+++ b/app-emulation/docker/files/docker.service
@@ -1,17 +1,17 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=http://docs.docker.com
-After=docker.socket early-docker.target network.target
-Requires=docker.socket early-docker.target
+After=containerd.service docker.socket early-docker.target network.target
+Requires=containerd.service docker.socket early-docker.target
 
 [Service]
 Type=notify
 EnvironmentFile=-/run/flannel/flannel_docker_opts.env
-MountFlags=slave
+
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/lib/coreos/dockerd --host=fd:// $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
+ExecStart=/usr/lib/coreos/dockerd --host=fd:// --containerd=/var/run/docker/libcontainerd/docker-containerd.sock $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
 ExecReload=/bin/kill -s HUP $MAINPID
 LimitNOFILE=1048576
 # Having non-zero Limit*s causes performance problems due to accounting overhead

--- a/app-emulation/docker/files/early-docker.service
+++ b/app-emulation/docker/files/early-docker.service
@@ -1,17 +1,17 @@
 [Unit]
 Description=Early Docker Application Container Engine
 Documentation=http://docs.docker.com
-After=early-docker.socket
-Requires=early-docker.socket
+After=containerd.service early-docker.socket
+Requires=containerd.service early-docker.socket
 
 [Service]
 Type=notify
 Environment=TMPDIR=/var/tmp
-MountFlags=slave
+
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/lib/coreos/dockerd --host=fd:// --bridge=none --iptables=false --ip-masq=false --exec-root=/var/run/early-docker --graph=/var/lib/early-docker --pidfile=/var/run/early-docker.pid $DOCKER_OPTS $DOCKER_CGROUPS
+ExecStart=/usr/lib/coreos/dockerd --host=fd:// --bridge=none --iptables=false --ip-masq=false --exec-root=/var/run/early-docker --graph=/var/lib/early-docker --pidfile=/var/run/early-docker.pid --containerd=/var/run/docker/libcontainerd/docker-containerd.sock $DOCKER_OPTS $DOCKER_CGROUPS
 ExecReload=/bin/kill -s HUP $MAINPID
 LimitNOFILE=1048576
 # Having non-zero Limit*s causes performance problems due to accounting overhead


### PR DESCRIPTION
Reviewers, please think about my associated manual test before approving. These changes continue to propose sharing the same containerd instance between early-docker and "real" docker, which seems to work fine.

Tested by pushing to GCE with the following userdata

```yaml
#cloud-config
write_files:
- path: "/root/dockerize.sh"
  permissions: "0755"
  owner: "root"
  content: |
    #!/bin/sh
    
    # Usage: dockerize.sh absolute-path image-name
    # Generates a docker image that contains the binary absolute-path
    # and registers it as image-name. Lots of unhandled corner cases,
    # just enough to work for our simple use case.
    
    dependencies() {
        echo $1
        LIBS_AND_JUNK=$(env -i ldd $1 | awk '{print $0}' RS=' ')
        for tok in $LIBS_AND_JUNK; do
            if test -f "$tok"; then
                echo "$tok"
            fi
        done
    }
    
    dependencies $1 | sort | uniq | tar cv -h -P -T - | docker import - $2
coreos:
  etcd2:
    discovery: https://discovery.etcd.io/90248cd879bd6ff90eb7be69847573b1
    advertise-client-urls: http://$private_ipv4:2379
    initial-advertise-peer-urls: http://$private_ipv4:2380
    listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
  units:
  - name: early-docker.socket
    enable: true
  - name: etcd2.service
    command: start
  - name: flanneld.service
    command: start
    drop-ins:
    - name: 50-network-config.conf
      content: |
        [Service]
        Environment="FLANNELD_V=9"
        ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{ "Network":"10.254.0.0/16" }'
  - name: docker.service
    drop-ins:
    - name: 50-docker-config.conf
      content: |
        [Unit]
        After=flanneld.service
        Requires=flanneld.service
  - name: earlytest.service
    command: start
    enable: true
    content: |
      [Unit]
      Description=Manual test of early-docker
      After=early-docker.socket early-docker.service
      Before=early-docker.target
      
      [Service]
      Type=oneshot
      Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
      ExecStartPre=-/root/dockerize.sh /usr/bin/ip early-ip
      ExecStart=/bin/echo "EARLY TEST RAN"
      ExecStart=/usr/bin/docker run early-ip ip address
      
      [Install]
      WantedBy=multi-user.target
```

- Observing that earlytest.service ran successfully after one reboot (so that early-docker was enabled in time)
- Running the following

```sh
sudo /root/dockerize `which ip` ip-exe-late
docker run -it ip-exe-late ip address
```
- Observing flannel-associated ip address in the output of docker run



