### PR TITLE
mantle: install legacy docker client for regression testing

### DIFF
--- a/coreos-devel/mantle/mantle-9999.ebuild
+++ b/coreos-devel/mantle/mantle-9999.ebuild
@@ -56,5 +56,7 @@ src_install() {
 		exeinto /usr/lib/kola/${a}
 		doexe "${GOBIN}/${a}/kolet"
 	done
-}
 
+    exeinto /usr/lib/kola/amd64
+    doexe vendor/binaries/amd64/docker-1.9.1
+}


### PR DESCRIPTION
This change must not be merged until https://github.com/coreos/mantle/pull/411 (or something very like it) is merged, or the ebuild will break.