### PR TITLE
profiles: use the same smartmontools version on arm64

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -35,7 +35,7 @@
 =sys-apps/i2c-tools-3.1.1-r1 ~arm64
 =sys-apps/lshw-02.17b-r2 **
 =sys-apps/rng-tools-5-r2 **
-=sys-apps/smartmontools-9999 **
+=sys-apps/smartmontools-6.4 **
 =sys-block/parted-3.2-r1 ~arm64
 =sys-devel/bison-3.0.4-r1 ~arm64
 =sys-fs/cryptsetup-1.7.2 **


### PR DESCRIPTION
This fixes the nightly Jenkins build failures.