### PR TITLE
coreos-sources: Add arm64 verity hash

### DIFF
--- a/sys-kernel/coreos-sources/coreos-sources-4.8.17.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-4.8.17.ebuild
@@ -43,4 +43,5 @@ UNIPATCH_LIST="
         ${PATCH_DIR}/z0019-efi-Add-EFI_SECURE_BOOT-bit.patch \
         ${PATCH_DIR}/z0020-hibernate-Disable-in-a-signed-modules-environment.patch \
         ${PATCH_DIR}/z0021-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch \
+        ${PATCH_DIR}/z0022-Add-arm64-coreos-verity-hash.patch \
 "

--- a/sys-kernel/coreos-sources/files/4.8/z0022-Add-arm64-coreos-verity-hash.patch
+++ b/sys-kernel/coreos-sources/files/4.8/z0022-Add-arm64-coreos-verity-hash.patch
@@ -1,0 +1,29 @@
+From 4c66942f5f1ce010fbe028256940ea9d50eb069e Mon Sep 17 00:00:00 2001
+From: Geoff Levand <geoff@infradead.org>
+Date: Fri, 11 Nov 2016 17:28:52 -0800
+Subject: [PATCH] Add arm64 coreos verity hash
+
+Signed-off-by: Geoff Levand <geoff@infradead.org>
+---
+ arch/arm64/kernel/head.S | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm64/kernel/head.S b/arch/arm64/kernel/head.S
+index 332e331..964bae1 100644
+--- a/arch/arm64/kernel/head.S
++++ b/arch/arm64/kernel/head.S
+@@ -195,6 +195,11 @@ section_table:
+ 	.short	0		// NumberOfLineNumbers  (0 for executables)
+ 	.long	0xe0500020	// Characteristics (section flags)
+ 
++	/* CoreOS 64 byte verity hash value. */
++	.org	_head + 512
++	.ascii	"verity-hash"
++	.org	_head + 512 + 64
++
+ 	/*
+ 	 * EFI will load .text onwards at the 4k section alignment
+ 	 * described in the PE/COFF header. To ensure that instruction
+-- 
+2.7.4
+


### PR DESCRIPTION
Adds a place to inject the verity hash value in the arm64 kernel image.

cc: @mjg59 