### PR TITLE
spidermonkey: Update CONFIG_ARM64_VA_BITS_48 fix

### DIFF
--- a/dev-lang/spidermonkey/files/spidermonkey-1.8.5-fix-arm64-va-48.patch
+++ b/dev-lang/spidermonkey/files/spidermonkey-1.8.5-fix-arm64-va-48.patch
@@ -1,21 +1,120 @@
-
-Fix for CONFIG_ARM64_VA_BITS_48=y
-https://bugzilla.redhat.com/show_bug.cgi?id=1242326
-
---- a/js/src/jsval.h.old
-+++ b/js/src/jsval.h
-@@ -236,8 +236,14 @@
+diff -urN js.orig/src/jsval.h js/src/jsval.h
+--- js.orig/src/jsval.h	2016-04-08 08:44:39.417713832 +0000
++++ js/src/jsval.h	2016-04-11 06:26:40.807919594 +0000
+@@ -66,7 +66,7 @@
+ #endif
+ 
+ #if JS_BITS_PER_WORD == 64
+-# define JSVAL_TAG_SHIFT 47
++# define JSVAL_TAG_SHIFT 48
+ #endif
+ 
+ /*
+@@ -135,7 +135,8 @@
+ /* Remember to propagate changes to the C defines below. */
+ JS_ENUM_HEADER(JSValueTag, uint32)
+ {
+-    JSVAL_TAG_MAX_DOUBLE           = 0x1FFF0,
++    JSVAL_TAG_DUMMY                = 0xFFFFFFFF,  /* Make sure the enums cannot fit 16-bits. */
++    JSVAL_TAG_MAX_DOUBLE           = 0xFFF8,
+     JSVAL_TAG_INT32                = JSVAL_TAG_MAX_DOUBLE | JSVAL_TYPE_INT32,
+     JSVAL_TAG_UNDEFINED            = JSVAL_TAG_MAX_DOUBLE | JSVAL_TYPE_UNDEFINED,
+     JSVAL_TAG_STRING               = JSVAL_TAG_MAX_DOUBLE | JSVAL_TYPE_STRING,
+@@ -196,7 +197,7 @@
+ #elif JS_BITS_PER_WORD == 64
+ 
+ typedef uint32 JSValueTag;
+-#define JSVAL_TAG_MAX_DOUBLE         ((uint32)(0x1FFF0))
++#define JSVAL_TAG_MAX_DOUBLE         ((uint32)(0xFFF8))
+ #define JSVAL_TAG_INT32              (uint32)(JSVAL_TAG_MAX_DOUBLE | JSVAL_TYPE_INT32)
+ #define JSVAL_TAG_UNDEFINED          (uint32)(JSVAL_TAG_MAX_DOUBLE | JSVAL_TYPE_UNDEFINED)
+ #define JSVAL_TAG_STRING             (uint32)(JSVAL_TAG_MAX_DOUBLE | JSVAL_TYPE_STRING)
+@@ -236,8 +237,8 @@
  
  #elif JS_BITS_PER_WORD == 64
  
-+#if defined(__aarch64__)
+-#define JSVAL_PAYLOAD_MASK           0x00007FFFFFFFFFFFLL
+-#define JSVAL_TAG_MASK               0xFFFF800000000000LL
 +#define JSVAL_PAYLOAD_MASK           0x0000FFFFFFFFFFFFLL
 +#define JSVAL_TAG_MASK               0xFFFF000000000000LL
-+#else
- #define JSVAL_PAYLOAD_MASK           0x00007FFFFFFFFFFFLL
- #define JSVAL_TAG_MASK               0xFFFF800000000000LL
-+#endif
-+
  #define JSVAL_TYPE_TO_TAG(type)      ((JSValueTag)(JSVAL_TAG_MAX_DOUBLE | (type)))
  #define JSVAL_TYPE_TO_SHIFTED_TAG(type) (((uint64)JSVAL_TYPE_TO_TAG(type)) << JSVAL_TAG_SHIFT)
  
+@@ -297,8 +298,8 @@
+ #if (!defined(_WIN64) && defined(__cplusplus))
+     /* MSVC does not pack these correctly :-( */
+     struct {
+-        uint64             payload47 : 47;
+-        JSValueTag         tag : 17;
++        uint64             payload48 : 48;
++        JSValueTag         tag : 16;
+     } debugView;
+ #endif
+     struct {
+@@ -339,8 +340,8 @@
+ {
+     uint64 asBits;
+     struct {
+-        JSValueTag         tag : 17;
+-        uint64             payload47 : 47;
++        JSValueTag         tag : 16;
++        uint64             payload48 : 48;
+     } debugView;
+     struct {
+         union {
+diff -urN js.orig/src/jsvalue.h js/src/jsvalue.h
+--- js.orig/src/jsvalue.h	2016-04-08 08:44:39.417713832 +0000
++++ js/src/jsvalue.h		2016-04-11 06:10:21.219479884 +0000
+@@ -255,7 +255,7 @@
+ {
+     uint64 lbits = lhs.asBits, rbits = rhs.asBits;
+     return (lbits <= JSVAL_TAG_MAX_DOUBLE && rbits <= JSVAL_TAG_MAX_DOUBLE) ||
+-           (((lbits ^ rbits) & 0xFFFF800000000000LL) == 0);
++           (((lbits ^ rbits) & 0xFFFF000000000000LL) == 0);
+ }
+ 
+ static JS_ALWAYS_INLINE jsval_layout
+@@ -277,7 +277,7 @@
+ static JS_ALWAYS_INLINE JSValueType
+ JSVAL_EXTRACT_NON_DOUBLE_TYPE_IMPL(jsval_layout l)
+ {
+-   uint64 type = (l.asBits >> JSVAL_TAG_SHIFT) & 0xF;
++   uint64 type = (l.asBits >> JSVAL_TAG_SHIFT) & 0x7;
+    JS_ASSERT(type > JSVAL_TYPE_DOUBLE);
+    return (JSValueType)type;
+ }
+--- js.orig/src/methodjit/MethodJIT.cpp	2016-10-12 13:08:07.307916254 -0400
++++ js/src/methodjit/MethodJIT.cpp	2016-10-12 13:08:59.647918787 -0400
+@@ -186,8 +186,8 @@
+ JS_STATIC_ASSERT(offsetof(VMFrame, savedRBX) == 0x58);
+ JS_STATIC_ASSERT(offsetof(VMFrame, regs.fp) == 0x38);
+ 
+-JS_STATIC_ASSERT(JSVAL_TAG_MASK == 0xFFFF800000000000LL);
+-JS_STATIC_ASSERT(JSVAL_PAYLOAD_MASK == 0x00007FFFFFFFFFFFLL);
++JS_STATIC_ASSERT(JSVAL_TAG_MASK == 0xFFFF000000000000LL);
++JS_STATIC_ASSERT(JSVAL_PAYLOAD_MASK == 0x0000FFFFFFFFFFFFLL);
+ 
+ asm volatile (
+ ".text\n"
+@@ -204,8 +204,8 @@
+     "pushq %rbx"                         "\n"
+ 
+     /* Load mask registers. */
+-    "movq $0xFFFF800000000000, %r13"     "\n"
+-    "movq $0x00007FFFFFFFFFFF, %r14"     "\n"
++    "movq $0xFFFF000000000000, %r13"     "\n"
++    "movq $0x0000FFFFFFFFFFFF, %r14"     "\n"
+ 
+     /* Build the JIT frame.
+      * rdi = cx
+@@ -675,8 +675,8 @@
+  */
+ JS_STATIC_ASSERT(offsetof(VMFrame, savedRBX) == 0x58);
+ JS_STATIC_ASSERT(offsetof(VMFrame, regs.fp) == 0x38);
+-JS_STATIC_ASSERT(JSVAL_TAG_MASK == 0xFFFF800000000000LL);
+-JS_STATIC_ASSERT(JSVAL_PAYLOAD_MASK == 0x00007FFFFFFFFFFFLL);
++JS_STATIC_ASSERT(JSVAL_TAG_MASK == 0xFFFF000000000000LL);
++JS_STATIC_ASSERT(JSVAL_PAYLOAD_MASK == 0x0000FFFFFFFFFFFFLL);
+ 
+ // Windows x64 uses assembler version since compiler doesn't support
+ // inline assembler

--- a/dev-lang/spidermonkey/spidermonkey-1.8.5-r5.ebuild
+++ b/dev-lang/spidermonkey/spidermonkey-1.8.5-r5.ebuild
@@ -61,8 +61,12 @@ src_prepare() {
 	# fix builds for alternate $ROOT locations
 	epatch "${FILESDIR}"/${P}-no-link-lib-deps.patch
 	# Fix for CONFIG_ARM64_VA_BITS_48=y
+	# https://github.com/coreos/coreos-overlay/pull/2241
+	# https://bugzilla.mozilla.org/show_bug.cgi?id=1143022
 	# https://bugzilla.redhat.com/show_bug.cgi?id=1242326
-	epatch "${FILESDIR}/${P}-fix-arm64-va-48.patch"
+	if [[ "${ARCH}" == "arm64" ]]; then
+		epatch "${FILESDIR}/${P}-fix-arm64-va-48.patch"
+	fi
 
 	epatch_user
 


### PR DESCRIPTION
An updated fix for the arm64 48 bit VA problem that causes polkit to crash on arm64.  Fixes arm64 runtime problems like these:  ```polkitd: unhandled level 3 translation fault (11)```

This fix uses the patch from @garygrebus's PR https://github.com/coreos/coreos-overlay/pull/2228, but to avoid the flannel problems the patch introduces on amd64, the patch is conditionally applied to arm64 only.

As discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1143022 this 48 bit VA problem has been fixed in newer versions of mozjs, but the memory management code of newer versions is very different, and a backport of that fix is not really possible.

Older PRs/comits for this problem:

  https://github.com/coreos/coreos-overlay/pull/2241 ```Revert "dev-lang/spidermonkey: Better fix for CONFIG_ARM64_VA_BITS_48"```
  https://github.com/coreos/coreos-overlay/pull/2228 ```dev-lang/spidermonkey: Better fix for CONFIG_ARM64_VA_BITS_48```
  https://github.com/coreos/coreos-overlay/pull/2049/commits/418741fdbcfba407b2edad23193d133fba547e34 ```dev-lang/spidermonkey: Fix for CONFIG_ARM64_VA_BITS_48```
