### PR TITLE
profiles: fix GLSA 201611-17 (rpcbind) on arm64

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -32,6 +32,8 @@
 # net-misc/wget: https://bugs.gentoo.org/show_bug.cgi?id=585926 / CVE-2016-4971
 =net-misc/wget-1.18 **
 =net-misc/whois-5.2.12 ~arm64
+# net-nds/rpcbind: https://security.gentoo.org/glsa/201611-17
+=net-nds/rpcbind-0.2.3-r1 ~arm64
 =sys-apps/ethtool-4.5 **
 =sys-apps/gptfdisk-1.0.1 ~arm64
 =sys-apps/i2c-tools-3.1.1-r1 ~arm64


### PR DESCRIPTION
This fixes today's Jenkins build failure.