### PR TITLE
app-emu/runc: enable selinux

### DIFF
--- a/app-emulation/runc/runc-1.0.0_rc1_p20160615-r2.ebuild
+++ b/app-emulation/runc/runc-1.0.0_rc1_p20160615-r2.ebuild
@@ -21,12 +21,13 @@ KEYWORDS="amd64 arm64"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-IUSE="apparmor +seccomp"
+IUSE="apparmor +selinux +seccomp"
 
 DEPEND=""
 RDEPEND="
 	apparmor? ( sys-libs/libapparmor )
 	seccomp? ( sys-libs/libseccomp )
+	selinux? ( sys-libs/libselinux )
 "
 
 src_prepare() {
@@ -43,6 +44,7 @@ src_compile() {
 	local options=(
 		$(usev apparmor)
 		$(usev seccomp)
+		$(usev selinux)
 	)
 
 	emake BUILDTAGS="${options[*]}"


### PR DESCRIPTION
runc needs to have selinux enabled for docker to be confined.