### PR TITLE
app-emu/runc: enable selinux

### DIFF
--- a/app-emulation/runc/runc-1.0.0_rc1_p20160615-r2.ebuild
+++ b/app-emulation/runc/runc-1.0.0_rc1_p20160615-r2.ebuild
@@ -21,12 +21,13 @@ KEYWORDS="amd64 arm64"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-IUSE="apparmor +seccomp"
+IUSE="apparmor +selinux +seccomp"
 
 DEPEND=""
 RDEPEND="
 	apparmor? ( sys-libs/libapparmor )
 	seccomp? ( sys-libs/libseccomp )
+	selinux? ( sys-libs/libselinux )
 "
 
 src_prepare() {
@@ -43,6 +44,7 @@ src_compile() {
 	local options=(
 		$(usev apparmor)
 		$(usev seccomp)
+		$(usev selinux)
 	)
 
 	emake BUILDTAGS="${options[*]}"

--- a/app-emulation/runc/runc-1.0.0_rc1_p20160615-r3.ebuild
+++ b/app-emulation/runc/runc-1.0.0_rc1_p20160615-r3.ebuild
@@ -21,13 +21,12 @@ KEYWORDS="amd64 arm64"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-IUSE="apparmor +selinux +seccomp"
+IUSE="apparmor selinux +seccomp"
 
 DEPEND=""
 RDEPEND="
 	apparmor? ( sys-libs/libapparmor )
 	seccomp? ( sys-libs/libseccomp )
-	selinux? ( sys-libs/libselinux )
 "
 
 src_prepare() {

--- a/profiles/coreos/amd64/generic/package.use
+++ b/profiles/coreos/amd64/generic/package.use
@@ -5,3 +5,6 @@ sys-apps/systemd            selinux
 
 # Enable SELinux for coreutils
 sys-apps/coreutils	    selinux
+
+# Enable SELinux for runc
+app-emulation/runc          selinux


### PR DESCRIPTION
runc needs to have selinux enabled for docker to be confined.