### PR TITLE
app-emulation/runc: Drop libselinux rdepend

### DIFF
--- a/app-emulation/runc/runc-1.0.0_rc1_p20160615-r3.ebuild
+++ b/app-emulation/runc/runc-1.0.0_rc1_p20160615-r3.ebuild
@@ -21,13 +21,12 @@ KEYWORDS="amd64 arm64"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-IUSE="apparmor +selinux +seccomp"
+IUSE="apparmor selinux +seccomp"
 
 DEPEND=""
 RDEPEND="
 	apparmor? ( sys-libs/libapparmor )
 	seccomp? ( sys-libs/libseccomp )
-	selinux? ( sys-libs/libselinux )
 "
 
 src_prepare() {

--- a/profiles/coreos/amd64/generic/package.use
+++ b/profiles/coreos/amd64/generic/package.use
@@ -5,3 +5,6 @@ sys-apps/systemd            selinux
 
 # Enable SELinux for coreutils
 sys-apps/coreutils	    selinux
+
+# Enable SELinux for runc
+app-emulation/runc          selinux


### PR DESCRIPTION
There's no dependency here - runc does appropriate setup directly, not with
cgo.