### PR TITLE
Expose container logs out of kubelet-wrapper

### DIFF
--- a/app-admin/kubelet-wrapper/files/kubelet-wrapper
+++ b/app-admin/kubelet-wrapper/files/kubelet-wrapper
@@ -54,7 +54,6 @@ fi
 mkdir --parents /etc/kubernetes
 mkdir --parents /var/lib/docker
 mkdir --parents /var/lib/kubelet
-mkdir --parents /var/log/containers
 mkdir --parents /run/kubelet
 
 RKT="${RKT:-/usr/bin/rkt}"
@@ -68,7 +67,7 @@ exec ${RKT} ${RKT_GLOBAL_ARGS} \
 	--volume usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
 	--volume var-lib-docker,kind=host,source=/var/lib/docker,readOnly=false \
 	--volume var-lib-kubelet,kind=host,source=/var/lib/kubelet,readOnly=false \
-	--volume var-log-containers,kind=host,source=/var/log/containers,readOnly=false \
+	--volume var-log,kind=host,source=/var/log,readOnly=false \
 	--volume os-release,kind=host,source=/usr/lib/os-release,readOnly=true \
 	--volume run,kind=host,source=/run,readOnly=false \
 	--mount volume=etc-kubernetes,target=/etc/kubernetes \
@@ -76,7 +75,7 @@ exec ${RKT} ${RKT_GLOBAL_ARGS} \
 	--mount volume=usr-share-certs,target=/usr/share/ca-certificates \
 	--mount volume=var-lib-docker,target=/var/lib/docker \
 	--mount volume=var-lib-kubelet,target=/var/lib/kubelet \
-	--mount volume=var-log-containers,target=/var/log/containers \
+	--mount volume=var-log,target=/var/log \
 	--mount volume=os-release,target=/etc/os-release \
 	--mount volume=run,target=/run \
 	${RKT_STAGE1_ARG} \

--- a/app-admin/kubelet-wrapper/files/kubelet-wrapper
+++ b/app-admin/kubelet-wrapper/files/kubelet-wrapper
@@ -54,6 +54,7 @@ fi
 mkdir --parents /etc/kubernetes
 mkdir --parents /var/lib/docker
 mkdir --parents /var/lib/kubelet
+mkdir --parents /var/log/containers
 mkdir --parents /run/kubelet
 
 RKT="${RKT:-/usr/bin/rkt}"
@@ -67,6 +68,7 @@ exec ${RKT} ${RKT_GLOBAL_ARGS} \
 	--volume usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
 	--volume var-lib-docker,kind=host,source=/var/lib/docker,readOnly=false \
 	--volume var-lib-kubelet,kind=host,source=/var/lib/kubelet,readOnly=false \
+	--volume var-log-containers,kind=host,source=/var/log/containers,readOnly=false \
 	--volume os-release,kind=host,source=/usr/lib/os-release,readOnly=true \
 	--volume run,kind=host,source=/run,readOnly=false \
 	--mount volume=etc-kubernetes,target=/etc/kubernetes \
@@ -74,6 +76,7 @@ exec ${RKT} ${RKT_GLOBAL_ARGS} \
 	--mount volume=usr-share-certs,target=/usr/share/ca-certificates \
 	--mount volume=var-lib-docker,target=/var/lib/docker \
 	--mount volume=var-lib-kubelet,target=/var/lib/kubelet \
+	--mount volume=var-log-containers,target=/var/log/containers \
 	--mount volume=os-release,target=/etc/os-release \
 	--mount volume=run,target=/run \
 	${RKT_STAGE1_ARG} \


### PR DESCRIPTION
The current version of the kubelet-wrapper does not expose the container logs to external utilities like fluentd.