### PR TITLE
profiles: move USE=-cracklib to base

### DIFF
--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -20,7 +20,7 @@ ETCD_PROTOCOLS="1 2"
 USE_EXPAND="${USE_EXPAND} GO_VERSION"
 
 # Extra use flags for CoreOS SDK
-USE="${USE} cros_host expat -introspection -cups -tcpd -berkdb"
+USE="${USE} cros_host expat -cracklib -introspection -cups -tcpd -berkdb"
 
 # Never install cron or cron jobs
 USE="${USE} -cron"

--- a/profiles/coreos/targets/generic/make.defaults
+++ b/profiles/coreos/targets/generic/make.defaults
@@ -3,7 +3,7 @@
 
 USE="cros-debug acpi usb symlink-usr cryptsetup policykit"
 USE="${USE} -cros_host -expat -cairo -X -man"
-USE="${USE} -acl -cracklib -gpm -python"
+USE="${USE} -acl -gpm -python"
 USE="${USE} -fortran -abiword -perl -cups -poppler-data -nls"
 
 # Exclude documentation


### PR DESCRIPTION
The `sys-apps/shadow` package in the SDK depends on `cracklib`.  It is not used by `shadow` in the images, and no other packages are using it.  With this dependency removed, `cracklib` can be dropped from portage-stable.