### PR TITLE
oem-vagrant: disable guest tools for parallels

### DIFF
--- a/coreos-base/oem-vagrant/files/box/Vagrantfile
+++ b/coreos-base/oem-vagrant/files/box/Vagrantfile
@@ -32,4 +32,10 @@ Vagrant.configure("2") do |config|
   config.vm.provider :vmware_fusion do |vf|
     vf.functional_hgfs = false
   end
-end
+
+  config.vm.provider :parallels do |prl|
+    # Guest Tools are unavailable.
+    prl.check_guest_tools = false
+    prl.functional_psf    = false
+  end
+ end


### PR DESCRIPTION
This PR disables guest tools for parallels/vagrant images.