### PR TITLE
Profile updates/cleanups in preparation for a portage-stable update

### DIFF
--- a/profiles/coreos/amd64/generic/use.mask
+++ b/profiles/coreos/amd64/generic/use.mask
@@ -1,0 +1,2 @@
+# Unmask selinux so it can be enabled selectively in package.use
+-selinux

--- a/profiles/coreos/amd64/package.use.force
+++ b/profiles/coreos/amd64/package.use.force
@@ -1,2 +1,0 @@
-# Do not force this flag, we don't need XATTR_PAX
-sys-apps/portage -xattr

--- a/profiles/coreos/amd64/usr/parent
+++ b/profiles/coreos/amd64/usr/parent
@@ -1,1 +1,0 @@
-:coreos/amd64/generic

--- a/profiles/coreos/arm64/package.use.force
+++ b/profiles/coreos/arm64/package.use.force
@@ -1,6 +1,3 @@
-# Do not force this flag, we don't need XATTR_PAX
-sys-apps/portage -xattr
-
 sys-auth/polkit -introspection
 sys-apps/systemd -introspection
 sys-fs/udev-init-scripts -introspection

--- a/profiles/coreos/arm64/use.mask
+++ b/profiles/coreos/arm64/use.mask
@@ -1,0 +1,2 @@
+# TODO(marineam): remove after portage-stable/profiles is updated.
+-seccomp

--- a/profiles/coreos/arm64/usr/parent
+++ b/profiles/coreos/arm64/usr/parent
@@ -1,1 +1,0 @@
-:coreos/arm64/generic

--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -32,9 +32,9 @@ USE="${USE} -zeroconf"
 # No need for OpenMP support in GCC and other apps
 USE="${USE} -openmp"
 
-# Test enabling seccomp globally prior to syncing other profile changes.
+# Test enabling some flags globally prior to syncing other profile changes.
 # TODO(marineam): remove after portage-stable/profiles is updated.
-USE="${USE} seccomp"
+USE="${USE} seccomp xattr"
 
 # Set SELinux policy
 POLICY_TYPES="targeted mcs mls"

--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -39,13 +39,6 @@ USE="${USE} seccomp"
 # Set SELinux policy
 POLICY_TYPES="targeted mcs mls"
 
-# Override upstream's python settings
-USE="$USE python_targets_python2_7 python_single_target_python2_7"
-USE="$USE -python_targets_python3_2 -python_single_target_python3_2"
-USE="$USE -python_targets_python3_3 -python_single_target_python3_3"
-BOOTSTRAP_USE="$BOOTSTRAP_USE -python_targets_python3_2"
-BOOTSTRAP_USE="$BOOTSTRAP_USE -python_targets_python3_3"
-
 # Disable packages or optional features with distribution issues.
 ACCEPT_RESTRICT="* -bindist -mirror"
 USE="${USE} bindist"

--- a/profiles/coreos/base/make.defaults
+++ b/profiles/coreos/base/make.defaults
@@ -32,6 +32,10 @@ USE="${USE} -zeroconf"
 # No need for OpenMP support in GCC and other apps
 USE="${USE} -openmp"
 
+# Test enabling seccomp globally prior to syncing other profile changes.
+# TODO(marineam): remove after portage-stable/profiles is updated.
+USE="${USE} seccomp"
+
 # Set SELinux policy
 POLICY_TYPES="targeted mcs mls"
 

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -36,8 +36,9 @@ net-analyzer/nmap ncat -lua
 # removes mta dependencies
 app-admin/sudo -sendmail
 
-# use lzma which is the default on non-gentoo systems
-sys-apps/systemd curl gcrypt lzma -lz4
+# use lzma which is the default on non-gentoo systems, avoid pulling in gnutls
+sys-apps/systemd curl gcrypt lzma -lz4 -ssl
+net-libs/libmicrohttpd -ssl
 
 # disable kernel config detection and module building
 net-firewall/ipset -modules

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -79,3 +79,5 @@ dev-cpp/glog gflags
 # enable rpc for rpc.rquotad
 sys-fs/quota rpc
 
+# Don't bother building portage w/xattr, we don't need XATTR_PAX
+sys-apps/portage -xattr

--- a/profiles/coreos/base/package.use.force
+++ b/profiles/coreos/base/package.use.force
@@ -1,2 +1,5 @@
 # Copyright (c) 2014 The CoreOS Authors. All rights reserved.
 # Distributed under the terms of the GNU General Public License v2
+
+# Do not force this flag, we don't need XATTR_PAX
+sys-apps/portage -xattr

--- a/profiles/coreos/base/use.mask
+++ b/profiles/coreos/base/use.mask
@@ -1,1 +1,10 @@
+# Never enable experimental code
 kdbus
+
+# Block python3 for now
+python_targets_python3_3
+python_targets_python3_4
+python_targets_python3_5
+python_single_target_python3_3
+python_single_target_python3_4
+python_single_target_python3_5

--- a/profiles/coreos/base/use.mask
+++ b/profiles/coreos/base/use.mask
@@ -1,2 +1,1 @@
 kdbus
--selinux

--- a/profiles/coreos/targets/generic/package.use
+++ b/profiles/coreos/targets/generic/package.use
@@ -41,7 +41,8 @@ app-shells/bash -net vanilla
 # disable nss utilities
 dev-libs/nss -utils
 
-# enable seccomp support in docker
-app-emulation/docker seccomp
-app-emulation/containerd seccomp
+# needed by docker
 sys-libs/libseccomp static-libs
+
+# bind-tools' configure script breaks when cross-compiling with seccomp enabled
+net-dns/bind-tools -seccomp

--- a/profiles/coreos/targets/generic/package.use
+++ b/profiles/coreos/targets/generic/package.use
@@ -22,11 +22,11 @@ sys-libs/ncurses	minimal
 sys-libs/pam        -berkdb
 sys-libs/gdbm		berkdb
 
-# enable journal gateway and container features, avoid pulling in gnutls
-sys-apps/systemd audit importd http nat -ssl
+# enable journal gateway and container features
+sys-apps/systemd audit importd http nat
 
 # epoll is needed for systemd-journal-remote to work. coreos/bugs#919
-net-libs/libmicrohttpd epoll -ssl
+net-libs/libmicrohttpd epoll
 
 sys-boot/syslinux       -custom-cflags
 


### PR DESCRIPTION
The only thing particularly interesting here are the seccomp and xattr flags. Upstream has enabled them by default and it seems fair to follow suit. amd64 already has xatter on all packages and seccomp on some. arm64 is the bigger change as it had both completely disabled. The end result is that the big portage-stable update will not toggle any flags.

All the rest of the churn is just trivial cleanups or tweaks to make diffing emerge results before and after the portage-stable update easier.