### PR TITLE
profiles: more arm64 package.accept_keywords cleanup

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -14,7 +14,6 @@
 =dev-libs/libassuan-2.4.3 ~arm64
 =dev-libs/libksba-1.3.5-r1 ~arm64
 =dev-libs/liblinear-210-r1 ~arm64
-=dev-libs/libpcre-8.38-r1
 =dev-libs/libxml2-2.9.4-r1 ~arm64
 =dev-libs/npth-1.2 ~arm64
 =dev-libs/nspr-4.12 ~arm64
@@ -32,7 +31,6 @@
 =net-misc/iperf-3.1.3 **
 =net-misc/whois-5.2.12 ~arm64
 =sys-apps/ethtool-4.5 **
-=sys-apps/file-5.25 ~arm64
 =sys-apps/gptfdisk-1.0.1 ~arm64
 =sys-apps/i2c-tools-3.1.1-r1 ~arm64
 =sys-apps/lshw-02.17b-r2 **
@@ -45,4 +43,3 @@
 =sys-fs/lvm2-2.02.145-r2 ~arm64
 =sys-fs/mdadm-3.4 **
 =sys-fs/quota-4.02 **
-=sys-fs/xfsprogs-4.5.0 **


### PR DESCRIPTION
This is the cleanup part of coreos/portage-stable#519.