### PR TITLE
profiles: sync nss and nspr versions on arm64

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -16,8 +16,8 @@
 =dev-libs/liblinear-210-r1 ~arm64
 =dev-libs/libxml2-2.9.4-r1 ~arm64
 =dev-libs/npth-1.2 ~arm64
-=dev-libs/nspr-4.12 ~arm64
-=dev-libs/nss-3.24 ~arm64
+=dev-libs/nspr-4.13.1 ~arm64
+=dev-libs/nss-3.28.1 ~arm64
 =dev-libs/userspace-rcu-0.9.1 **
 =net-analyzer/nmap-7.12 ~arm64
 =net-analyzer/tcpdump-4.7.4-r1 ~arm64


### PR DESCRIPTION
Part of coreos/portage-stable#520.