### PR TITLE
app-emulation/runc: workaround userns issue

### DIFF
--- a/app-emulation/runc/files/0002-Dont-set-label-for-mqueue-under-userns.patch
+++ b/app-emulation/runc/files/0002-Dont-set-label-for-mqueue-under-userns.patch
@@ -1,0 +1,94 @@
+From 3ce50afe04f102cf28dbb6425773011707bf3ae0 Mon Sep 17 00:00:00 2001
+From: Mrunal Patel <mrunalp@gmail.com>
+Date: Wed, 12 Oct 2016 16:46:59 -0700
+Subject: [PATCH] Fix setting SELinux label for mqueue when user namespaces are
+ enabled
+
+If one tries to user SELinux with user namespaces, then labeling of /dev/mqueue
+fails because the IPC namespace belongs to the root in init_user_ns. This
+commit fixes that by unsharing IPC namespace after we clone into a new USER
+namespace so the IPC namespace is owned by the root inside the new USER
+namespace as opposed to init_user_ns.
+
+Signed-off-by: Mrunal Patel <mrunalp@gmail.com>
+---
+ libcontainer/nsenter/nsexec.c | 25 ++++++++++++++++++++-----
+ 1 file changed, 20 insertions(+), 5 deletions(-)
+
+diff --git a/libcontainer/nsenter/nsexec.c b/libcontainer/nsenter/nsexec.c
+index b93f827..1e8d4da 100644
+--- a/libcontainer/nsenter/nsexec.c
++++ b/libcontainer/nsenter/nsexec.c
+@@ -94,14 +94,20 @@ static int child_func(void *arg)
+ 	longjmp(*ca->env, JUMP_VAL);
+ }
+ 
+-static int clone_parent(jmp_buf *env, int flags) __attribute__ ((noinline));
+-static int clone_parent(jmp_buf *env, int flags)
++static int clone_parent(jmp_buf *env, int flags, bool delay_ipc_unshare) __attribute__ ((noinline));
++static int clone_parent(jmp_buf *env, int flags, bool delay_ipc_unshare)
+ {
+ 	int child;
+ 	struct clone_arg ca = {
+ 		.env = env,
+ 	};
+ 
++	// Don't clone into NEWIPC at the same time as cloning into NEWUSER.
++	// This way we can ensure that NEWIPC namespace belongs to the root in new user namespace.
++	if (delay_ipc_unshare) {
++		flags &= ~CLONE_NEWIPC;
++	}
++
+ 	child = clone(child_func, ca.stack_ptr, CLONE_PARENT | SIGCHLD | flags, &ca);
+ 
+ 	/*
+@@ -227,7 +233,7 @@ static void update_gidmap(int pid, char *map, int map_len)
+ 
+ #define JSON_MAX 4096
+ 
+-static void start_child(int pipenum, jmp_buf *env, int syncpipe[2], struct nlconfig_t *config)
++static void start_child(int pipenum, jmp_buf *env, int syncpipe[2], struct nlconfig_t *config, bool delay_ipc_unshare)
+ {
+ 	int len, childpid;
+ 	char buf[JSON_MAX];
+@@ -239,7 +245,7 @@ static void start_child(int pipenum, jmp_buf *env, int syncpipe[2], struct nlcon
+ 	 * (the bootstrap process). Also so we don't need to forward the
+ 	 * child's exit code or resend its death signal.
+ 	 */
+-	childpid = clone_parent(env, config->cloneflags);
++	childpid = clone_parent(env, config->cloneflags, delay_ipc_unshare);
+ 	if (childpid < 0)
+ 		bail("unable to fork");
+ 
+@@ -415,6 +421,9 @@ void nsexec(void)
+ 	if (config.cloneflags == -1)
+ 		bail("missing clone_flags");
+ 
++	bool delay_ipc_unshare = ((config.cloneflags & CLONE_NEWUSER) == CLONE_NEWUSER)
++		&& ((config.cloneflags & CLONE_NEWIPC) == CLONE_NEWIPC);
++
+ 	/* Pipe so we can tell the child when we've finished setting up. */
+ 	if (pipe(syncpipe) < 0)
+ 		bail("failed to setup sync pipe between parent and child");
+@@ -447,6 +456,12 @@ void nsexec(void)
+ 		if (setgroups(0, NULL) < 0)
+ 			bail("setgroups failed");
+ 
++		if (delay_ipc_unshare) {
++			if (unshare(CLONE_NEWIPC)) {
++				bail("unable to unshare IPC namespace");
++			}
++		}
++
+ 		if (consolefd != -1) {
+ 			if (ioctl(consolefd, TIOCSCTTY, 0) < 0)
+ 				bail("ioctl TIOCSCTTY failed");
+@@ -466,7 +481,7 @@ void nsexec(void)
+ 	}
+ 
+ 	/* Run the parent code. */
+-	start_child(pipenum, &env, syncpipe, &config);
++	start_child(pipenum, &env, syncpipe, &config, delay_ipc_unshare);
+ 
+ 	/* Should never be reached. */
+ 	bail("should never be reached");

--- a/app-emulation/runc/runc-1.0.0_rc2-r3.ebuild
+++ b/app-emulation/runc/runc-1.0.0_rc2-r3.ebuild
@@ -9,6 +9,7 @@ COREOS_GO_PACKAGE="${GITHUB_URI}"
 COREOS_GO_VERSION="go1.6"
 # the commit of runc that docker uses.
 # see https://github.com/docker/docker/blob/v1.12.6/Dockerfile#L245
+# Note: this commit is only really present in `docker/runc` in the 'docker/1.12.x' branch
 COMMIT_ID="50a19c6ff828c58e5dab13830bd3dacde268afe5"
 
 inherit eutils flag-o-matic coreos-go-depend vcs-snapshot
@@ -31,6 +32,7 @@ RDEPEND="
 
 src_prepare() {
 	epatch "${FILESDIR}/0001-Makefile-do-not-install-dependencies-of-target.patch"
+	epatch "${FILESDIR}/0002-Dont-set-label-for-mqueue-under-userns.patch"
 
 	# Work around https://github.com/golang/go/issues/14669
 	# Remove after updating to go1.7


### PR DESCRIPTION
This fixes a bug in usernamespace support under selinux.
This patch matches the one applied to fedora.

Read more about this exciting tale in: https://github.com/opencontainers/runc/pull/959, https://github.com/projectatomic/runc/commit/3ce50afe04f102cf28dbb6425773011707bf3ae0

cc @crawford 