### PR TITLE
sys-kernel/coreos-sources: backport selinux+userns patch

### DIFF
--- a/sys-kernel/coreos-kernel/coreos-kernel-4.8.17-r1.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-4.8.17-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION=""
+COREOS_SOURCE_REVISION="-r1"
 inherit coreos-kernel
 
 DESCRIPTION="CoreOS Linux kernel"

--- a/sys-kernel/coreos-modules/coreos-modules-4.8.17-r1.ebuild
+++ b/sys-kernel/coreos-modules/coreos-modules-4.8.17-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION=""
+COREOS_SOURCE_REVISION="-r1"
 inherit coreos-kernel savedconfig
 
 DESCRIPTION="CoreOS Linux kernel modules"

--- a/sys-kernel/coreos-sources/coreos-sources-4.8.17-r1.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-4.8.17-r1.ebuild
@@ -44,4 +44,5 @@ UNIPATCH_LIST="
         ${PATCH_DIR}/z0020-hibernate-Disable-in-a-signed-modules-environment.patch \
         ${PATCH_DIR}/z0021-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch \
         ${PATCH_DIR}/z0022-Add-arm64-coreos-verity-hash.patch \
+        ${PATCH_DIR}/z0023-selinux-allow-context-mounts-on-tmpfs-ramfs-devpts-within-user-namespaces.patch \
 "

--- a/sys-kernel/coreos-sources/files/4.8/z0023-selinux-allow-context-mounts-on-tmpfs-ramfs-devpts-within-user-namespaces.patch
+++ b/sys-kernel/coreos-sources/files/4.8/z0023-selinux-allow-context-mounts-on-tmpfs-ramfs-devpts-within-user-namespaces.patch
@@ -1,0 +1,57 @@
+From 01593d3299a1cfdb5e08acf95f63ec59dd674906 Mon Sep 17 00:00:00 2001
+From: Stephen Smalley <sds@tycho.nsa.gov>
+Date: Mon, 9 Jan 2017 10:07:31 -0500
+Subject: selinux: allow context mounts on tmpfs, ramfs, devpts within user
+ namespaces
+
+commit aad82892af261b9903cc11c55be3ecf5f0b0b4f8 ("selinux: Add support for
+unprivileged mounts from user namespaces") prohibited any use of context
+mount options within non-init user namespaces.  However, this breaks
+use of context mount options for tmpfs mounts within user namespaces,
+which are being used by Docker/runc.  There is no reason to block such
+usage for tmpfs, ramfs or devpts.  Exempt these filesystem types
+from this restriction.
+
+Before:
+sh$ userns_child_exec  -p -m -U -M '0 1000 1' -G '0 1000 1' bash
+sh# mount -t tmpfs -o context=system_u:object_r:user_tmp_t:s0:c13 none /tmp
+mount: tmpfs is write-protected, mounting read-only
+mount: cannot mount tmpfs read-only
+
+After:
+sh$ userns_child_exec  -p -m -U -M '0 1000 1' -G '0 1000 1' bash
+sh# mount -t tmpfs -o context=system_u:object_r:user_tmp_t:s0:c13 none /tmp
+sh# ls -Zd /tmp
+unconfined_u:object_r:user_tmp_t:s0:c13 /tmp
+
+Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>
+Signed-off-by: Paul Moore <paul@paul-moore.com>
+---
+ security/selinux/hooks.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/security/selinux/hooks.c b/security/selinux/hooks.c
+index e4b953f..e32f4b5 100644
+--- a/security/selinux/hooks.c
++++ b/security/selinux/hooks.c
+@@ -834,10 +834,14 @@ static int selinux_set_mnt_opts(struct super_block *sb,
+ 	}
+ 
+ 	/*
+-	 * If this is a user namespace mount, no contexts are allowed
+-	 * on the command line and security labels must be ignored.
++	 * If this is a user namespace mount and the filesystem type is not
++	 * explicitly whitelisted, then no contexts are allowed on the command
++	 * line and security labels must be ignored.
+ 	 */
+-	if (sb->s_user_ns != &init_user_ns) {
++	if (sb->s_user_ns != &init_user_ns &&
++	    strcmp(sb->s_type->name, "tmpfs") &&
++	    strcmp(sb->s_type->name, "ramfs") &&
++	    strcmp(sb->s_type->name, "devpts")) {
+ 		if (context_sid || fscontext_sid || rootcontext_sid ||
+ 		    defcontext_sid) {
+ 			rc = -EACCES;
+-- 
+cgit v0.12
+


### PR DESCRIPTION
Upstream as https://git.kernel.org/cgit/linux/kernel/git/next/linux-next.git/commit/?id=01593d3299a1cfdb5e08acf95f63ec59dd674906

See also https://github.com/opencontainers/runc/issues/1215