### PR TITLE
coreos-overlay/oem-packet: Remove bond workaround

### DIFF
--- a/coreos-base/oem-packet/files/cloud-config.yml
+++ b/coreos-base/oem-packet/files/cloud-config.yml
@@ -2,22 +2,12 @@
 
 coreos:
   units:
-    - name: oem-reset-interfaces.service
-      command: start
-      content: |
-        [Unit]
-        Description=Reset the bond.
-        [Service]
-        Type=oneshot
-        ExecStart=/usr/share/oem/bin/reset-interfaces.sh
     - name: oem-cloudinit.service
       command: restart
       runtime: yes
       content: |
         [Unit]
         Description=Cloudinit from Packet metadata
-        After=oem-reset-interfaces.service
-        Requires=oem-reset-interfaces.service
 
         [Service]
         Type=oneshot

--- a/coreos-base/oem-packet/files/reset-interfaces.sh
+++ b/coreos-base/oem-packet/files/reset-interfaces.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-logger "Hard reset of all network interfaces due to upstream systemd-networkd issue: https://github.com/coreos/bugs/issues/36 ."
-for iface in `ls -1 /sys/class/net | egrep -v "(^lo$|^bond)"`; do
-	ip link set $iface down
-done
-ip link del bond0
-systemctl restart systemd-networkd

--- a/coreos-base/oem-packet/oem-packet-0.0.5.ebuild
+++ b/coreos-base/oem-packet/oem-packet-0.0.5.ebuild
@@ -22,7 +22,6 @@ src_prepare() {
 src_install() {
 	into "/usr/share/oem"
 	dobin "${FILESDIR}/phone-home.sh"
-	dobin "${FILESDIR}/reset-interfaces.sh"
 
 	insinto "/usr/share/oem"
 	doins "${T}/cloud-config.yml"


### PR DESCRIPTION
Now that Packet uses Ignition to configure systemd-networkd units
before systemd-networkd starts, the workaround described in the
below issue is no longer necessary:

https://github.com/coreos/bugs/issues/36