### PR TITLE
sys-libs/ncurses: add rxvt-unicode-256color

### DIFF
--- a/sys-libs/ncurses/ncurses-5.9-r8.ebuild
+++ b/sys-libs/ncurses/ncurses-5.9-r8.ebuild
@@ -37,7 +37,7 @@ PDEPEND="gpm? ( sys-libs/gpm[${MULTILIB_USEDEP}] )"
 S=${WORKDIR}/${MY_P}
 HOSTTIC_DIR=${WORKDIR}/${P}-host
 
-MINIMAL_TERMINFO=(ansi console dumb linux rxvt rxvt-256color rxvt-unicode \
+MINIMAL_TERMINFO=(ansi console dumb linux rxvt rxvt-256color rxvt-unicode rxvt-unicode-256color \
 				  screen screen-16color screen-256color sun vt{52,100,102,200,220} \
 				  xterm xterm-color xterm-256color xterm-xfree86)
 


### PR DESCRIPTION
Every once in a while, I stumble upon this error message because the terminfo for `rxvt-unicode-256color` is missing in CoreOS:
```
WARNING: terminal is not fully functional
-  (press RETURN)
```

`rxvt-unicode` is a quite popular terminal emulator and, at least on [Arch](https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/rxvt-unicode#n32), compiled with [`--enable-256-color`](http://cvs.schmorp.de/rxvt-unicode/README.configure?view=markup#l240). I figured it's worth a try to get this fix upstream instead of working around this problem over and over again...