### PR TITLE
Upgrade pesign

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -108,3 +108,6 @@ dev-util/checkbashisms
 
 # xfsprogs 4.5.0 has install conflicts, and versions in between fail to link
 =sys-fs/xfsprogs-4.9.0 **
+
+# pesign has no stable version at the moment, so accept the one with pesigcheck
+=app-crypt/pesign-0.112 **


### PR DESCRIPTION
This doesn't install pesign into any CoreOS targets by default.  It just makes it available for manually emerging a la `sys-firmware/edk2-armvirt` in Jenkins.

Part of coreos/portage-stable#523.