### PR TITLE
sys-kernel/coreos-sources: Stop routing primary console to ttyS0

### DIFF
--- a/sys-kernel/coreos-kernel/coreos-kernel-4.8.17-r3.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-4.8.17-r3.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION="-r1"
+COREOS_SOURCE_REVISION="-r2"
 inherit coreos-kernel
 
 DESCRIPTION="CoreOS Linux kernel"

--- a/sys-kernel/coreos-modules/coreos-modules-4.8.17-r3.ebuild
+++ b/sys-kernel/coreos-modules/coreos-modules-4.8.17-r3.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION="-r1"
+COREOS_SOURCE_REVISION="-r2"
 inherit coreos-kernel savedconfig
 
 DESCRIPTION="CoreOS Linux kernel modules"

--- a/sys-kernel/coreos-sources/coreos-sources-4.8.17-r2.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-4.8.17-r2.ebuild
@@ -45,4 +45,5 @@ UNIPATCH_LIST="
         ${PATCH_DIR}/z0021-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch \
         ${PATCH_DIR}/z0022-Add-arm64-coreos-verity-hash.patch \
         ${PATCH_DIR}/z0023-selinux-allow-context-mounts-on-tmpfs-ramfs-devpts-within-user-namespaces.patch \
+        ${PATCH_DIR}/z0024-Revert-tty-serial-8250-add-CON_CONSDEV-to-flags.patch \
 "

--- a/sys-kernel/coreos-sources/files/4.8/z0024-Revert-tty-serial-8250-add-CON_CONSDEV-to-flags.patch
+++ b/sys-kernel/coreos-sources/files/4.8/z0024-Revert-tty-serial-8250-add-CON_CONSDEV-to-flags.patch
@@ -1,0 +1,40 @@
+From e47cbf707c26036420fec8846d07ec640b744c0e Mon Sep 17 00:00:00 2001
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Sun, 11 Dec 2016 10:05:49 +0800
+Subject: [PATCH] Revert "tty: serial: 8250: add CON_CONSDEV to flags"
+
+This commit needs to be reverted because it prevents people from
+using the serial console as a secondary console with input being
+directed to tty0.
+
+IOW, if you boot with console=ttyS0 console=tty0 then all kernels
+prior to this commit will produce output on both ttyS0 and tty0
+but input will only be taken from tty0.  With this patch the serial
+console will always be the primary console instead of tty0,
+potentially preventing people from getting into their machines in
+emergency situations.
+
+Fixes: d03516df8375 ("tty: serial: 8250: add CON_CONSDEV to flags")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Cc: stable <stable@vger.kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/tty/serial/8250/8250_core.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/tty/serial/8250/8250_core.c b/drivers/tty/serial/8250/8250_core.c
+index dcf43f6..fa823a5 100644
+--- a/drivers/tty/serial/8250/8250_core.c
++++ b/drivers/tty/serial/8250/8250_core.c
+@@ -675,7 +675,7 @@ static struct console univ8250_console = {
+ 	.device		= uart_console_device,
+ 	.setup		= univ8250_console_setup,
+ 	.match		= univ8250_console_match,
+-	.flags		= CON_PRINTBUFFER | CON_ANYTIME | CON_CONSDEV,
++	.flags		= CON_PRINTBUFFER | CON_ANYTIME,
+ 	.index		= -1,
+ 	.data		= &serial8250_reg,
+ };
+-- 
+2.9.3
+


### PR DESCRIPTION
Our GRUB config specifies tty0 as the primary console, but it was being forced to the serial port instead. As a result, boot failures produced no visible error messages on tty0, and the emergency shell was likewise inaccessible.

Backports #2417 to alpha.