### PR TITLE
app-emulation/runc: re-apply non-dumpable patch

### DIFF
--- a/app-emulation/runc/files/runc-1.0.0_rc2-init-non-dumpable.patch
+++ b/app-emulation/runc/files/runc-1.0.0_rc2-init-non-dumpable.patch
@@ -1,0 +1,108 @@
+From 50a19c6ff828c58e5dab13830bd3dacde268afe5 Mon Sep 17 00:00:00 2001
+From: Michael Crosby <crosbymichael@gmail.com>
+Date: Wed, 7 Dec 2016 15:05:51 -0800
+Subject: [PATCH] Set init processes as non-dumpable
+
+This sets the init processes that join and setup the container's
+namespaces as non-dumpable before they setns to the container's pid (or
+any other ) namespace.
+
+This settings is automatically reset to the default after the Exec in
+the container so that it does not change functionality for the
+applications that are running inside, just our init processes.
+
+This prevents parent processes, the pid 1 of the container, to ptrace
+the init process before it drops caps and other sets LSMs.
+
+This patch also ensures that the stateDirFD being used is still closed
+prior to exec, even though it is set as O_CLOEXEC, because of the order
+in the kernel.
+
+https://github.com/torvalds/linux/blob/v4.9/fs/exec.c#L1290-L1318
+
+The order during the exec syscall is that the process is set back to
+dumpable before O_CLOEXEC are processed.
+
+Signed-off-by: Michael Crosby <crosbymichael@gmail.com>
+---
+ libcontainer/init_linux.go          | 3 ++-
+ libcontainer/nsenter/nsexec.c       | 5 +++++
+ libcontainer/setns_init_linux.go    | 7 ++++++-
+ libcontainer/standard_init_linux.go | 3 +++
+ 4 files changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/libcontainer/init_linux.go b/libcontainer/init_linux.go
+index b1e6762..4043d51 100644
+--- a/libcontainer/init_linux.go
++++ b/libcontainer/init_linux.go
+@@ -77,7 +77,8 @@ func newContainerInit(t initType, pipe *os.File, stateDirFD int) (initer, error)
+ 	switch t {
+ 	case initSetns:
+ 		return &linuxSetnsInit{
+-			config: config,
++			config:     config,
++			stateDirFD: stateDirFD,
+ 		}, nil
+ 	case initStandard:
+ 		return &linuxStandardInit{
+diff --git a/libcontainer/nsenter/nsexec.c b/libcontainer/nsenter/nsexec.c
+index b93f827..4b5398b 100644
+--- a/libcontainer/nsenter/nsexec.c
++++ b/libcontainer/nsenter/nsexec.c
+@@ -408,6 +408,11 @@ void nsexec(void)
+ 	if (pipenum == -1)
+ 		return;
+ 
++	/* make the process non-dumpable */
++	if (prctl(PR_SET_DUMPABLE, 0, 0, 0, 0) != 0) {
++		bail("failed to set process as non-dumpable");
++	}
++
+ 	/* Parse all of the netlink configuration. */
+ 	nl_parse(pipenum, &config);
+ 
+diff --git a/libcontainer/setns_init_linux.go b/libcontainer/setns_init_linux.go
+index 2a8f345..7f5f182 100644
+--- a/libcontainer/setns_init_linux.go
++++ b/libcontainer/setns_init_linux.go
+@@ -5,6 +5,7 @@ package libcontainer
+ import (
+ 	"fmt"
+ 	"os"
++	"syscall"
+ 
+ 	"github.com/opencontainers/runc/libcontainer/apparmor"
+ 	"github.com/opencontainers/runc/libcontainer/keys"
+@@ -16,7 +17,8 @@ import (
+ // linuxSetnsInit performs the container's initialization for running a new process
+ // inside an existing container.
+ type linuxSetnsInit struct {
+-	config *initConfig
++	config     *initConfig
++	stateDirFD int
+ }
+ 
+ func (l *linuxSetnsInit) getSessionRingName() string {
+@@ -49,5 +51,8 @@ func (l *linuxSetnsInit) Init() error {
+ 	if err := label.SetProcessLabel(l.config.ProcessLabel); err != nil {
+ 		return err
+ 	}
++	// close the statedir fd before exec because the kernel resets dumpable in the wrong order
++	// https://github.com/torvalds/linux/blob/v4.9/fs/exec.c#L1290-L1318
++	syscall.Close(l.stateDirFD)
+ 	return system.Execv(l.config.Args[0], l.config.Args[0:], os.Environ())
+ }
+diff --git a/libcontainer/standard_init_linux.go b/libcontainer/standard_init_linux.go
+index 2104f1a..6a65154 100644
+--- a/libcontainer/standard_init_linux.go
++++ b/libcontainer/standard_init_linux.go
+@@ -171,6 +171,9 @@ func (l *linuxStandardInit) Init() error {
+ 			return newSystemErrorWithCause(err, "init seccomp")
+ 		}
+ 	}
++	// close the statedir fd before exec because the kernel resets dumpable in the wrong order
++	// https://github.com/torvalds/linux/blob/v4.9/fs/exec.c#L1290-L1318
++	syscall.Close(l.stateDirFD)
+ 	if err := syscall.Exec(name, l.config.Args[0:], os.Environ()); err != nil {
+ 		return newSystemErrorWithCause(err, "exec user process")
+ 	}

--- a/app-emulation/runc/runc-1.0.0_rc2-r4.ebuild
+++ b/app-emulation/runc/runc-1.0.0_rc2-r4.ebuild
@@ -7,10 +7,7 @@ EAPI=5
 GITHUB_URI="github.com/opencontainers/runc"
 COREOS_GO_PACKAGE="${GITHUB_URI}"
 COREOS_GO_VERSION="go1.6"
-# the commit of runc that docker uses.
-# see https://github.com/docker/docker/blob/v1.12.6/Dockerfile#L245
-# Note: this commit is only really present in `docker/runc` in the 'docker/1.12.x' branch
-COMMIT_ID="50a19c6ff828c58e5dab13830bd3dacde268afe5"
+COMMIT_ID="c91b5bea4830a57eac7882d7455d59518cdf70ec" # v1.0.0-rc2
 
 inherit eutils flag-o-matic coreos-go-depend vcs-snapshot
 
@@ -31,6 +28,7 @@ RDEPEND="
 "
 
 src_prepare() {
+	epatch "${FILESDIR}/runc-1.0.0_rc2-init-non-dumpable.patch"
 	epatch "${FILESDIR}/0001-Makefile-do-not-install-dependencies-of-target.patch"
 	epatch "${FILESDIR}/0002-Dont-set-label-for-mqueue-under-userns.patch"
 


### PR DESCRIPTION
This re-fixes CVE-2016-9962

Due to reusing the same "${P}" as upstream gentoo and also using their
distfile mirror, the downloaded source tarball was not for the
EGIT_COMMIT referenced in the ebuild, and so did not include the patch.

I've also updated the EGIT_COMMIT to match what's really being used,
though it's still ignored in this change.

The patchfile was taken from gentoo's overlay.

This was done rather than fixing the ebuild to use the intended commit
simply because it ends up being a smaller change. The proper change to
use the commit intended will be done on other channels.