### PR TITLE
coreos/config/env: make gettext builds stay inside the sysroot

### DIFF
--- a/coreos/config/env/sys-devel/gettext
+++ b/coreos/config/env/sys-devel/gettext
@@ -1,0 +1,1 @@
+EXTRA_ECONF="--with-libncurses-prefix=${ROOT}usr --with-libxml2-prefix=${ROOT}usr"


### PR DESCRIPTION
This is only an issue when the glibc versions differ between the SDK and the sysroot.  The M4 library detection functions in gettext do bad things on their own, so bypass them.