### PR TITLE
profiles: update GCC to a stable version

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -67,12 +67,6 @@ dev-util/checkbashisms
 # Fixes conflict with man-pages 4.00
 =sys-apps/attr-2.4.47-r2
 
-# Upgrade to GCC 4.9, improves arm64 support, adds -fstack-protector-strong
-# Note: ~arch for cross compilers much be explicit.
-=sys-devel/gcc-4.9.3
-=cross-aarch64-cros-linux-gnu/gcc-4.9.3 ~arm64
-=cross-x86_64-cros-linux-gnu/gcc-4.9.3  ~amd64
-
 # newer btrfs-progs improve things like preserving capabilities in send/receive
 # https://github.com/coreos/bugs/issues/923
 =sys-fs/btrfs-progs-4.2.2 ~amd64 ~arm64


### PR DESCRIPTION
This is part of coreos/portage-stable#527.