### PR TITLE
profiles/coreos: Turn on sudo support in sssd

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -69,7 +69,7 @@ net-dns/bind-tools gssapi
 dev-libs/cyrus-sasl kerberos -berkdb -gdbm
 
 # don't build manpages for sssd
-sys-auth/sssd -manpages -python kerberos gssapi ssh
+sys-auth/sssd -manpages -python kerberos gssapi ssh sudo
 
 # needed for realmd build
 sys-auth/polkit introspection


### PR DESCRIPTION
Build the sudo-related helpers for sssd.
So sudoers can be retrieve from LDAP.

coreos/bugs#1856