### PR TITLE
dev-libs/openssl: generate /etc/ssl at boot

### DIFF
--- a/dev-libs/openssl/files/openssl.conf
+++ b/dev-libs/openssl/files/openssl.conf
@@ -1,0 +1,3 @@
+d	/etc/ssl		-	-	-	-	-
+d	/etc/ssl/private	0700	-	-	-	-
+L	/etc/ssl/openssl.cnf	-	-	-	-	../../usr/share/ssl/openssl.cnf


### PR DESCRIPTION
This fixes a few `openssl` commands such as `req` on PXE at least and takes out the sample CA scripts.

Note that this also wipes out `/etc/ssl` in the SDK (aside from `certs`), but I haven't hit any build failures from it yet.  We might want to handle that case at some point anyway.