### PR TITLE
coreos-base/oem-hyperv: switch to ignition scheme

### DIFF
--- a/coreos-base/oem-hyperv/files/cloud-config.yml
+++ b/coreos-base/oem-hyperv/files/cloud-config.yml
@@ -1,8 +1,0 @@
-#cloud-config
-
-coreos:
-    oem:
-      id: hyperv
-      name: Microsoft Hyper-V
-      version-id: @@OEM_VERSION_ID@@
-      bug-report-url: https://issues.coreos.com

--- a/coreos-base/oem-hyperv/files/oem-release
+++ b/coreos-base/oem-hyperv/files/oem-release
@@ -1,0 +1,4 @@
+ID=hyperv
+VERSION_ID=@@OEM_VERSION_ID@@
+NAME="Microsoft Hyper-V"
+BUG_REPORT_URL="https://issues.coreos.com"

--- a/coreos-base/oem-hyperv/oem-hyperv-0.0.3-r1.ebuild
+++ b/coreos-base/oem-hyperv/oem-hyperv-0.0.3-r1.ebuild
@@ -16,12 +16,12 @@ IUSE=""
 S="${WORKDIR}"
 
 src_prepare() {
-    sed -e "s\\@@OEM_VERSION_ID@@\\${PVR}\\g" \
-        "${FILESDIR}/cloud-config.yml" > "${T}/cloud-config.yml" || die
+	sed -e "s\\@@OEM_VERSION_ID@@\\${PVR}\\g" \
+		"${FILESDIR}/oem-release" > "${T}/oem-release" || die
 }
 
 src_install() {
 	insinto "/usr/share/oem"
-	doins "${T}/cloud-config.yml"
 	doins "${FILESDIR}/grub.cfg"
+	doins "${T}/oem-release"
 }


### PR DESCRIPTION
Since there is no cloud-config to drop here, just bring this OEM inline
with the others in terms of their structure.