### PR TITLE
dev-libs/openssl: package /etc/ssl for SDK bootstrapping

### DIFF
--- a/dev-libs/openssl/openssl-1.0.2k-r2.ebuild
+++ b/dev-libs/openssl/openssl-1.0.2k-r2.ebuild
@@ -244,5 +244,8 @@ multilib_src_install_all() {
 	dodir /usr/share/ssl
 	insinto /usr/share/ssl
 	doins "${S}"/apps/openssl.cnf
-	systemd_dotmpfilesd ${FILESDIR}/openssl.conf
+	systemd_dotmpfilesd "${FILESDIR}"/openssl.conf
+
+	# Package the tmpfiles.d setup for SDK bootstrapping.
+	systemd-tmpfiles --create --root="${ED}" "${FILESDIR}"/openssl.conf
 }


### PR DESCRIPTION
This fixes the nightly build failure from an `openssl req` call in building the SDK stage4.