### PR TITLE
sys-kernel/coreos-sources: Apply CVE-2017-7184 fix

### DIFF
--- a/sys-kernel/coreos-kernel/coreos-kernel-4.9.16-r1.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-4.9.16-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION=""
+COREOS_SOURCE_REVISION="-r1"
 inherit coreos-kernel
 
 DESCRIPTION="CoreOS Linux kernel"

--- a/sys-kernel/coreos-modules/coreos-modules-4.9.16-r1.ebuild
+++ b/sys-kernel/coreos-modules/coreos-modules-4.9.16-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION=""
+COREOS_SOURCE_REVISION="-r1"
 inherit coreos-kernel savedconfig
 
 DESCRIPTION="CoreOS Linux kernel modules"

--- a/sys-kernel/coreos-sources/coreos-sources-4.9.16-r1.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-4.9.16-r1.ebuild
@@ -40,4 +40,6 @@ UNIPATCH_LIST="
 	${PATCH_DIR}/z0016-selinux-allow-context-mounts-on-tmpfs-ramfs-devpts-w.patch \
 	${PATCH_DIR}/z0017-perf-x86-intel-rapl-Make-package-handling-more-robus.patch \
 	${PATCH_DIR}/z0018-perf-x86-intel-uncore-Make-package-handling-more-rob.patch \
+	${PATCH_DIR}/z0019-xfrm_user-validate-XFRM_MSG_NEWAE-XFRMA_REPLAY_ESN_V.patch \
+	${PATCH_DIR}/z0020-xfrm_user-validate-XFRM_MSG_NEWAE-incoming-ESN-size-.patch \
 "

--- a/sys-kernel/coreos-sources/files/4.9/z0001-Add-secure_modules-call.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0001-Add-secure_modules-call.patch
@@ -1,7 +1,7 @@
 From df8cc01cd6aa1baf94065347c97092a7237dfc4d Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <matthew.garrett@nebula.com>
 Date: Fri, 9 Aug 2013 17:58:15 -0400
-Subject: [PATCH 01/18] Add secure_modules() call
+Subject: [PATCH 01/20] Add secure_modules() call
 
 Provide a single call to allow kernel code to determine whether the system
 has been configured to either disable module loading entirely or to load
@@ -59,5 +59,5 @@ index 0e54d5b..085b720 100644
 +}
 +EXPORT_SYMBOL(secure_modules);
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0002-PCI-Lock-down-BAR-access-when-module-security-is-ena.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0002-PCI-Lock-down-BAR-access-when-module-security-is-ena.patch
@@ -1,7 +1,7 @@
 From 88ab41c69f30e022376812efd0ac765aca458767 Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <matthew.garrett@nebula.com>
 Date: Thu, 8 Mar 2012 10:10:38 -0500
-Subject: [PATCH 02/18] PCI: Lock down BAR access when module security is
+Subject: [PATCH 02/20] PCI: Lock down BAR access when module security is
  enabled
 
 Any hardware that can potentially generate DMA has to be locked down from
@@ -114,5 +114,5 @@ index b91c4da..98f5637 100644
  
  	dev = pci_get_bus_and_slot(bus, dfn);
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0003-x86-Lock-down-IO-port-access-when-module-security-is.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0003-x86-Lock-down-IO-port-access-when-module-security-is.patch
@@ -1,7 +1,7 @@
 From 34183c12cacd1f69819a85c1713df9d3f3caa987 Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <matthew.garrett@nebula.com>
 Date: Thu, 8 Mar 2012 10:35:59 -0500
-Subject: [PATCH 03/18] x86: Lock down IO port access when module security is
+Subject: [PATCH 03/20] x86: Lock down IO port access when module security is
  enabled
 
 IO port access would permit users to gain access to PCI configuration
@@ -68,5 +68,5 @@ index 6d9cc2d..a6eca51 100644
  		return -EFAULT;
  	while (count-- > 0 && i < 65536) {
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0004-ACPI-Limit-access-to-custom_method.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0004-ACPI-Limit-access-to-custom_method.patch
@@ -1,7 +1,7 @@
 From 6cbf54a30d9bb7d4143f56226033e3e86e53916b Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <matthew.garrett@nebula.com>
 Date: Fri, 9 Mar 2012 08:39:37 -0500
-Subject: [PATCH 04/18] ACPI: Limit access to custom_method
+Subject: [PATCH 04/20] ACPI: Limit access to custom_method
 
 custom_method effectively allows arbitrary access to system memory, making
 it possible for an attacker to circumvent restrictions on module loading.
@@ -27,5 +27,5 @@ index c68e724..4277938 100644
  		/* parse the table header to get the table length */
  		if (count <= sizeof(struct acpi_table_header))
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0005-asus-wmi-Restrict-debugfs-interface-when-module-load.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0005-asus-wmi-Restrict-debugfs-interface-when-module-load.patch
@@ -1,7 +1,7 @@
 From 4c66903e14fbabdc3cb1aba6a2f3536b45e1bf04 Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <matthew.garrett@nebula.com>
 Date: Fri, 9 Mar 2012 08:46:50 -0500
-Subject: [PATCH 05/18] asus-wmi: Restrict debugfs interface when module
+Subject: [PATCH 05/20] asus-wmi: Restrict debugfs interface when module
  loading is restricted
 
 We have no way of validating what all of the Asus WMI methods do on a
@@ -50,5 +50,5 @@ index ce6ca31..55d2399 100644
  				     1, asus->debug.method_id,
  				     &input, &output);
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0006-Restrict-dev-mem-and-dev-kmem-when-module-loading-is.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0006-Restrict-dev-mem-and-dev-kmem-when-module-loading-is.patch
@@ -1,7 +1,7 @@
 From 2a92fdde6e696773a761be4196fc3abfe7a90922 Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <matthew.garrett@nebula.com>
 Date: Fri, 9 Mar 2012 09:28:15 -0500
-Subject: [PATCH 06/18] Restrict /dev/mem and /dev/kmem when module loading is
+Subject: [PATCH 06/20] Restrict /dev/mem and /dev/kmem when module loading is
  restricted
 
 Allowing users to write to address space makes it possible for the kernel
@@ -38,5 +38,5 @@ index a6eca51..191b2b0 100644
  		unsigned long to_write = min_t(unsigned long, count,
  					       (unsigned long)high_memory - p);
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0007-acpi-Ignore-acpi_rsdp-kernel-parameter-when-module-l.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0007-acpi-Ignore-acpi_rsdp-kernel-parameter-when-module-l.patch
@@ -1,7 +1,7 @@
 From 99828f8ead6c0e65517bb8d9248d7ed876baa095 Mon Sep 17 00:00:00 2001
 From: Josh Boyer <jwboyer@redhat.com>
 Date: Mon, 25 Jun 2012 19:57:30 -0400
-Subject: [PATCH 07/18] acpi: Ignore acpi_rsdp kernel parameter when module
+Subject: [PATCH 07/20] acpi: Ignore acpi_rsdp kernel parameter when module
  loading is restricted
 
 This option allows userspace to pass the RSDP address to the kernel, which
@@ -35,5 +35,5 @@ index 416953a..4887e34 100644
  #endif
  
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0008-kexec-Disable-at-runtime-if-the-kernel-enforces-modu.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0008-kexec-Disable-at-runtime-if-the-kernel-enforces-modu.patch
@@ -1,7 +1,7 @@
 From 693d9601dab7d5d1a295a6a1a4d657c35c3caa79 Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <mjg59@coreos.com>
 Date: Thu, 19 Nov 2015 18:55:53 -0800
-Subject: [PATCH 08/18] kexec: Disable at runtime if the kernel enforces module
+Subject: [PATCH 08/20] kexec: Disable at runtime if the kernel enforces module
  loading restrictions
 
 kexec permits the loading and execution of arbitrary code in ring 0, which
@@ -35,5 +35,5 @@ index 980936a..a0e4cb3 100644
  
  	/*
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0009-x86-Restrict-MSR-access-when-module-loading-is-restr.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0009-x86-Restrict-MSR-access-when-module-loading-is-restr.patch
@@ -1,7 +1,7 @@
 From 18a014112cd43e3f07f43a01aa95a64f88d6f9c6 Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <matthew.garrett@nebula.com>
 Date: Fri, 8 Feb 2013 11:12:13 -0800
-Subject: [PATCH 09/18] x86: Restrict MSR access when module loading is
+Subject: [PATCH 09/20] x86: Restrict MSR access when module loading is
  restricted
 
 Writing to MSRs should not be allowed if module loading is restricted,
@@ -40,5 +40,5 @@ index 7f3550a..963ba40 100644
  			err = -EFAULT;
  			break;
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0010-Add-option-to-automatically-enforce-module-signature.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0010-Add-option-to-automatically-enforce-module-signature.patch
@@ -1,7 +1,7 @@
 From c3aa37345d0630e1373ebedc74d4ad703ac188b4 Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <matthew.garrett@nebula.com>
 Date: Fri, 9 Aug 2013 18:36:30 -0400
-Subject: [PATCH 10/18] Add option to automatically enforce module signatures
+Subject: [PATCH 10/20] Add option to automatically enforce module signatures
  when in Secure Boot mode
 
 UEFI Secure Boot provides a mechanism for ensuring that the firmware will
@@ -181,5 +181,5 @@ index 085b720..e0c6216 100644
  {
  #ifdef CONFIG_MODULE_SIG
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0011-efi-Make-EFI_SECURE_BOOT_SIG_ENFORCE-depend-on-EFI.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0011-efi-Make-EFI_SECURE_BOOT_SIG_ENFORCE-depend-on-EFI.patch
@@ -1,7 +1,7 @@
 From d24ed01f940f689853f011cf6b4a5ef0348b6298 Mon Sep 17 00:00:00 2001
 From: Josh Boyer <jwboyer@fedoraproject.org>
 Date: Tue, 27 Aug 2013 13:28:43 -0400
-Subject: [PATCH 11/18] efi: Make EFI_SECURE_BOOT_SIG_ENFORCE depend on EFI
+Subject: [PATCH 11/20] efi: Make EFI_SECURE_BOOT_SIG_ENFORCE depend on EFI
 
 The functionality of the config option is dependent upon the platform being
 UEFI based.  Reflect this in the config deps.
@@ -26,5 +26,5 @@ index 882da2b..d666ef8b 100644
  	---help---
  	  UEFI Secure Boot provides a mechanism for ensuring that the
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0012-efi-Add-EFI_SECURE_BOOT-bit.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0012-efi-Add-EFI_SECURE_BOOT-bit.patch
@@ -1,7 +1,7 @@
 From 7214ed2cf5897de06a88d02d5d56f0f24de4d618 Mon Sep 17 00:00:00 2001
 From: Josh Boyer <jwboyer@fedoraproject.org>
 Date: Tue, 27 Aug 2013 13:33:03 -0400
-Subject: [PATCH 12/18] efi: Add EFI_SECURE_BOOT bit
+Subject: [PATCH 12/20] efi: Add EFI_SECURE_BOOT bit
 
 UEFI machines can be booted in Secure Boot mode.  Add a EFI_SECURE_BOOT bit
 for use with efi_enabled.
@@ -39,5 +39,5 @@ index cba7177..0d76705 100644
  #ifdef CONFIG_EFI
  /*
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0013-hibernate-Disable-in-a-signed-modules-environment.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0013-hibernate-Disable-in-a-signed-modules-environment.patch
@@ -1,7 +1,7 @@
 From 4dccaaf1224d669cd389b73f5a08ad6585dddd6d Mon Sep 17 00:00:00 2001
 From: Josh Boyer <jwboyer@fedoraproject.org>
 Date: Fri, 20 Jun 2014 08:53:24 -0400
-Subject: [PATCH 13/18] hibernate: Disable in a signed modules environment
+Subject: [PATCH 13/20] hibernate: Disable in a signed modules environment
 
 There is currently no way to verify the resume image when returning
 from hibernate.  This might compromise the signed modules trust model,
@@ -35,5 +35,5 @@ index b26dbc4..ab187ad 100644
  
  /**
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0014-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0014-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch
@@ -1,7 +1,7 @@
 From 0a8a0ce702fd515be9760fe346141ec7fc573722 Mon Sep 17 00:00:00 2001
 From: Vito Caputo <vito.caputo@coreos.com>
 Date: Wed, 25 Nov 2015 02:59:45 -0800
-Subject: [PATCH 14/18] kbuild: derive relative path for KBUILD_SRC from CURDIR
+Subject: [PATCH 14/20] kbuild: derive relative path for KBUILD_SRC from CURDIR
 
 This enables relocating source and build trees to different roots,
 provided they stay reachable relative to one another.  Useful for
@@ -26,5 +26,5 @@ index 4e0f962..faf9a4e 100644
  
  # Leave processing to above invocation of make
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0015-Add-arm64-coreos-verity-hash.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0015-Add-arm64-coreos-verity-hash.patch
@@ -1,7 +1,7 @@
 From 7a818fda9a3bd22b2260e784dd701127352c4465 Mon Sep 17 00:00:00 2001
 From: Geoff Levand <geoff@infradead.org>
 Date: Fri, 11 Nov 2016 17:28:52 -0800
-Subject: [PATCH 15/18] Add arm64 coreos verity hash
+Subject: [PATCH 15/20] Add arm64 coreos verity hash
 
 Signed-off-by: Geoff Levand <geoff@infradead.org>
 ---
@@ -25,5 +25,5 @@ index 332e331..964bae1 100644
  	 * EFI will load .text onwards at the 4k section alignment
  	 * described in the PE/COFF header. To ensure that instruction
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0016-selinux-allow-context-mounts-on-tmpfs-ramfs-devpts-w.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0016-selinux-allow-context-mounts-on-tmpfs-ramfs-devpts-w.patch
@@ -1,7 +1,7 @@
 From 3dd3b4054303b5ca3c7ef59869c352569a5c8f58 Mon Sep 17 00:00:00 2001
 From: Stephen Smalley <sds@tycho.nsa.gov>
 Date: Mon, 9 Jan 2017 10:07:31 -0500
-Subject: [PATCH 16/18] selinux: allow context mounts on tmpfs, ramfs, devpts
+Subject: [PATCH 16/20] selinux: allow context mounts on tmpfs, ramfs, devpts
  within user namespaces
 
 commit aad82892af261b9903cc11c55be3ecf5f0b0b4f8 ("selinux: Add support for
@@ -53,5 +53,5 @@ index c2da45a..799a691 100644
  		    defcontext_sid) {
  			rc = -EACCES;
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0017-perf-x86-intel-rapl-Make-package-handling-more-robus.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0017-perf-x86-intel-rapl-Make-package-handling-more-robus.patch
@@ -1,7 +1,7 @@
 From d96d7de8baec200cb4837127a91cd12180c31273 Mon Sep 17 00:00:00 2001
 From: Thomas Gleixner <tglx@linutronix.de>
 Date: Tue, 31 Jan 2017 23:58:38 +0100
-Subject: [PATCH 17/18] perf/x86/intel/rapl: Make package handling more robust
+Subject: [PATCH 17/20] perf/x86/intel/rapl: Make package handling more robust
 
 The package management code in RAPL relies on package mapping being
 available before a CPU is started. This changed with:
@@ -45,7 +45,7 @@ Signed-off-by: Ingo Molnar <mingo@kernel.org>
  2 files changed, 26 insertions(+), 35 deletions(-)
 
 diff --git a/arch/x86/events/intel/rapl.c b/arch/x86/events/intel/rapl.c
-index 0a535cea..1dba3c2 100644
+index 0a535ce..1dba3c2 100644
 --- a/arch/x86/events/intel/rapl.c
 +++ b/arch/x86/events/intel/rapl.c
 @@ -161,7 +161,13 @@ static u64 rapl_timer_ms;
@@ -175,5 +175,5 @@ index ba1cad7..965cc56 100644
  	CPUHP_PERF_POWER,
  	CPUHP_PERF_SUPERH,
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0018-perf-x86-intel-uncore-Make-package-handling-more-rob.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0018-perf-x86-intel-uncore-Make-package-handling-more-rob.patch
@@ -1,7 +1,7 @@
 From 4926886baa1be9bee6c0872538673588e8562b81 Mon Sep 17 00:00:00 2001
 From: Thomas Gleixner <tglx@linutronix.de>
 Date: Tue, 31 Jan 2017 23:58:40 +0100
-Subject: [PATCH 18/18] perf/x86/intel/uncore: Make package handling more
+Subject: [PATCH 18/20] perf/x86/intel/uncore: Make package handling more
  robust
 
 The package management code in uncore relies on package mapping being
@@ -305,5 +305,5 @@ index 965cc56..ce83119 100644
  	CPUHP_AP_PERF_X86_STARTING,
  	CPUHP_AP_PERF_X86_AMD_IBS_STARTING,
 -- 
-2.7.4
+2.9.3
 

--- a/sys-kernel/coreos-sources/files/4.9/z0019-xfrm_user-validate-XFRM_MSG_NEWAE-XFRMA_REPLAY_ESN_V.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0019-xfrm_user-validate-XFRM_MSG_NEWAE-XFRMA_REPLAY_ESN_V.patch
@@ -1,0 +1,49 @@
+From 342ddb07be66138010864196e659053babdbbd03 Mon Sep 17 00:00:00 2001
+From: Andy Whitcroft <apw@canonical.com>
+Date: Wed, 22 Mar 2017 07:29:31 +0000
+Subject: [PATCH 19/20] xfrm_user: validate XFRM_MSG_NEWAE XFRMA_REPLAY_ESN_VAL
+ replay_window
+
+When a new xfrm state is created during an XFRM_MSG_NEWSA call we
+validate the user supplied replay_esn to ensure that the size is valid
+and to ensure that the replay_window size is within the allocated
+buffer.  However later it is possible to update this replay_esn via a
+XFRM_MSG_NEWAE call.  There we again validate the size of the supplied
+buffer matches the existing state and if so inject the contents.  We do
+not at this point check that the replay_window is within the allocated
+memory.  This leads to out-of-bounds reads and writes triggered by
+netlink packets.  This leads to memory corruption and the potential for
+priviledge escalation.
+
+We already attempt to validate the incoming replay information in
+xfrm_new_ae() via xfrm_replay_verify_len().  This confirms that the user
+is not trying to change the size of the replay state buffer which
+includes the replay_esn.  It however does not check the replay_window
+remains within that buffer.  Add validation of the contained
+replay_window.
+
+CVE-2017-7184
+Signed-off-by: Andy Whitcroft <apw@canonical.com>
+Acked-by: Steffen Klassert <steffen.klassert@secunet.com>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+---
+ net/xfrm/xfrm_user.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/net/xfrm/xfrm_user.c b/net/xfrm/xfrm_user.c
+index 671a1d0..98420bf 100644
+--- a/net/xfrm/xfrm_user.c
++++ b/net/xfrm/xfrm_user.c
+@@ -415,6 +415,9 @@ static inline int xfrm_replay_verify_len(struct xfrm_replay_state_esn *replay_es
+ 	if (nla_len(rp) < ulen || xfrm_replay_state_esn_len(replay_esn) != ulen)
+ 		return -EINVAL;
+ 
++	if (up->replay_window > up->bmp_len * sizeof(__u32) * 8)
++		return -EINVAL;
++
+ 	return 0;
+ }
+ 
+-- 
+2.9.3
+

--- a/sys-kernel/coreos-sources/files/4.9/z0020-xfrm_user-validate-XFRM_MSG_NEWAE-incoming-ESN-size-.patch
+++ b/sys-kernel/coreos-sources/files/4.9/z0020-xfrm_user-validate-XFRM_MSG_NEWAE-incoming-ESN-size-.patch
@@ -1,0 +1,39 @@
+From 91258cce259dd90adcae0e4ce1dcae809e94d008 Mon Sep 17 00:00:00 2001
+From: Andy Whitcroft <apw@canonical.com>
+Date: Thu, 23 Mar 2017 07:45:44 +0000
+Subject: [PATCH 20/20] xfrm_user: validate XFRM_MSG_NEWAE incoming ESN size
+ harder
+
+Kees Cook has pointed out that xfrm_replay_state_esn_len() is subject to
+wrapping issues.  To ensure we are correctly ensuring that the two ESN
+structures are the same size compare both the overall size as reported
+by xfrm_replay_state_esn_len() and the internal length are the same.
+
+CVE-2017-7184
+Signed-off-by: Andy Whitcroft <apw@canonical.com>
+Acked-by: Steffen Klassert <steffen.klassert@secunet.com>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+---
+ net/xfrm/xfrm_user.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/net/xfrm/xfrm_user.c b/net/xfrm/xfrm_user.c
+index 98420bf..a7e27e1 100644
+--- a/net/xfrm/xfrm_user.c
++++ b/net/xfrm/xfrm_user.c
+@@ -412,7 +412,11 @@ static inline int xfrm_replay_verify_len(struct xfrm_replay_state_esn *replay_es
+ 	up = nla_data(rp);
+ 	ulen = xfrm_replay_state_esn_len(up);
+ 
+-	if (nla_len(rp) < ulen || xfrm_replay_state_esn_len(replay_esn) != ulen)
++	/* Check the overall length and the internal bitmap length to avoid
++	 * potential overflow. */
++	if (nla_len(rp) < ulen ||
++	    xfrm_replay_state_esn_len(replay_esn) != ulen ||
++	    replay_esn->bmp_len != up->bmp_len)
+ 		return -EINVAL;
+ 
+ 	if (up->replay_window > up->bmp_len * sizeof(__u32) * 8)
+-- 
+2.9.3
+


### PR DESCRIPTION
For stable.

I'll admit I haven't successfully built this yet due to the wonders of perl in our sdk right now.