### PR TITLE
app-admin/kubelet-wrapper: mark kubelet datadir volume as a recursive mount

### DIFF
--- a/app-admin/kubelet-wrapper/files/kubelet-wrapper
+++ b/app-admin/kubelet-wrapper/files/kubelet-wrapper
@@ -66,7 +66,7 @@ exec ${RKT} ${RKT_GLOBAL_ARGS} \
 	--volume etc-ssl-certs,kind=host,source=/etc/ssl/certs,readOnly=true \
 	--volume usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
 	--volume var-lib-docker,kind=host,source=/var/lib/docker,readOnly=false \
-	--volume var-lib-kubelet,kind=host,source=/var/lib/kubelet,readOnly=false \
+	--volume var-lib-kubelet,kind=host,source=/var/lib/kubelet,readOnly=false,recursive=true \
 	--volume var-log,kind=host,source=/var/log,readOnly=false \
 	--volume os-release,kind=host,source=/usr/lib/os-release,readOnly=true \
 	--volume run,kind=host,source=/run,readOnly=false \


### PR DESCRIPTION
So far `/var/lib/kubelet` was mounted as an implicit non-recursive mount.
This changes the wrapper to an explicit recursive mount.

As shown in https://github.com/kubernetes/kubernetes/issues/38498#issuecomment-282493681,
current non-recursive behavior seems to confuse the kubelet which
is incapable of cleaning up resources for orphaned pods, as the
extisting mountpoints for them are not available inside kubelet
chroot.
With `recursive=true`, those mounts are made available in the
chroot and can be unmounted on the host-side from kubelet chroot
via shared back-propagation.

Fixes https://github.com/coreos/bugs/issues/1831