### PR TITLE
Sync GLSAs

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -28,7 +28,6 @@
 =net-libs/libpcap-1.7.4 ~arm64
 =net-libs/serf-1.3.8-r1 ~arm64
 =net-misc/bridge-utils-1.5 ~arm64
-=net-misc/curl-7.52.1-r1 **
 =net-misc/iperf-3.1.3 **
 =net-misc/whois-5.2.12 ~arm64
 =sys-apps/ethtool-4.5 **


### PR DESCRIPTION
The current stable curl ebuild matches both amd64 and arm64, so drop our old explicit accept_keywords line.

Part of coreos/portage-stable#535.