### PR TITLE
Revert "Merge pull request #2308 from sapcc/master"

### DIFF
--- a/app-admin/kubelet-wrapper/files/kubelet-wrapper
+++ b/app-admin/kubelet-wrapper/files/kubelet-wrapper
@@ -67,7 +67,6 @@ exec ${RKT} ${RKT_GLOBAL_ARGS} \
 	--volume usr-share-certs,kind=host,source=/usr/share/ca-certificates,readOnly=true \
 	--volume var-lib-docker,kind=host,source=/var/lib/docker,readOnly=false \
 	--volume var-lib-kubelet,kind=host,source=/var/lib/kubelet,readOnly=false \
-	--volume var-log,kind=host,source=/var/log,readOnly=false \
 	--volume os-release,kind=host,source=/usr/lib/os-release,readOnly=true \
 	--volume run,kind=host,source=/run,readOnly=false \
 	--mount volume=etc-kubernetes,target=/etc/kubernetes \
@@ -75,7 +74,6 @@ exec ${RKT} ${RKT_GLOBAL_ARGS} \
 	--mount volume=usr-share-certs,target=/usr/share/ca-certificates \
 	--mount volume=var-lib-docker,target=/var/lib/docker \
 	--mount volume=var-lib-kubelet,target=/var/lib/kubelet \
-	--mount volume=var-log,target=/var/log \
 	--mount volume=os-release,target=/etc/os-release \
 	--mount volume=run,target=/run \
 	${RKT_STAGE1_ARG} \


### PR DESCRIPTION
This reverts commit 14be7e884c211d222c168daedfc75487f86d4dfb, reversing
changes made to 144812b4f9e5104b09a5122a49933501308a16b9.

See https://github.com/coreos/bugs/issues/1892

Fixing that issue correctly turns out to be more complicated than expected (requiring patching rkt fly), so let's hold this fix out of stable for one more cycle.

It's better to have the state of the world before this (kubelet-wrapper boots, but doesn't have logs plumbed out unless you manually add mounts) than after (kubelet-wrapper fails to boot if you had configured logs).