### PR TITLE
app-emulation/containerd: build with go1.7

### DIFF
--- a/app-emulation/containerd/containerd-0.2.5-r2.ebuild
+++ b/app-emulation/containerd/containerd-0.2.5-r2.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 
 GITHUB_URI="github.com/docker/${PN}"
 COREOS_GO_PACKAGE="${GITHUB_URI}"
-COREOS_GO_VERSION="go1.6"
+COREOS_GO_VERSION="go1.7"
 
 MY_PV="${PV/_/-}"
 EGIT_COMMIT="v${MY_PV}"

--- a/app-emulation/docker/docker-1.12.6-r2.ebuild
+++ b/app-emulation/docker/docker-1.12.6-r2.ebuild
@@ -61,7 +61,7 @@ RDEPEND="
 	>=app-arch/xz-utils-4.9
 	>=sys-apps/shadow-4.4
 
-	=app-emulation/containerd-0.2.5-r1[seccomp?]
+	=app-emulation/containerd-0.2.5-r2[seccomp?]
 	=app-emulation/runc-1.0.0_rc2_p9[apparmor?,seccomp?]
 "
 


### PR DESCRIPTION
This is the Docker 1.12 version of the commit in #2514 for stable.