### PR TITLE
Cherry-pick enabling Packet on arm64 for stable

### DIFF
--- a/coreos-base/oem-packet/oem-packet-0.0.5.ebuild
+++ b/coreos-base/oem-packet/oem-packet-0.0.5.ebuild
@@ -9,7 +9,7 @@ SRC_URI=""
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 arm64 x86"
 
 # no source directory
 S="${WORKDIR}"


### PR DESCRIPTION
Currently, we have to run a different branch of the Jenkins scripts to build stable releases so they don't attempt to build Packet images on `arm64`.  I remember @crawford didn't want to backport this when the branch was still in beta, but now that it is in stable, if we apply this and build the image, it will never be published.  So this PR has no user-visible effect, but it cleans up the overhead of us having to remember to use different build procedures.  Any concerns with this @crawford/@euank?