### PR TITLE
profiles: bump arm64 versions for GLSAs

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -12,12 +12,13 @@
 =dev-libs/apr-1.5.2 ~arm64
 =dev-libs/apr-util-1.5.4-r1 ~arm64
 =dev-libs/libassuan-2.4.3 ~arm64
+=dev-libs/libevent-2.1.8 ~arm64
 =dev-libs/libksba-1.3.5-r1 ~arm64
 =dev-libs/liblinear-210-r1 ~arm64
 =dev-libs/libxml2-2.9.4-r1 ~arm64
 =dev-libs/npth-1.2 ~arm64
 =dev-libs/nspr-4.13.1 ~arm64
-=dev-libs/nss-3.28.1 ~arm64
+=dev-libs/nss-3.29.5 ~arm64
 =dev-libs/userspace-rcu-0.9.1 **
 =media-libs/libpng-1.6.27 ~arm64
 =net-analyzer/nmap-7.12 ~arm64


### PR DESCRIPTION
Part of coreos/portage-stable#550.