### PR TITLE
Allow kubelet to load missing kernel modules

### DIFF
--- a/app-admin/kubelet-wrapper/files/kubelet-wrapper
+++ b/app-admin/kubelet-wrapper/files/kubelet-wrapper
@@ -70,6 +70,7 @@ exec ${RKT} ${RKT_GLOBAL_ARGS} \
 	--volume coreos-var-log,kind=host,source=/var/log,readOnly=false \
 	--volume coreos-os-release,kind=host,source=/usr/lib/os-release,readOnly=true \
 	--volume coreos-run,kind=host,source=/run,readOnly=false \
+	--volume coreos-lib-modules,kind=host,source=/lib/modules,readOnly=true \
 	--mount volume=coreos-etc-kubernetes,target=/etc/kubernetes \
 	--mount volume=coreos-etc-ssl-certs,target=/etc/ssl/certs \
 	--mount volume=coreos-usr-share-certs,target=/usr/share/ca-certificates \
@@ -78,6 +79,7 @@ exec ${RKT} ${RKT_GLOBAL_ARGS} \
 	--mount volume=coreos-var-log,target=/var/log \
 	--mount volume=coreos-os-release,target=/etc/os-release \
 	--mount volume=coreos-run,target=/run \
+	--mount volume=coreos-lib-modules,target=/lib/modules \
 	${RKT_STAGE1_ARG} \
 	${KUBELET_IMAGE} \
 		${KUBELET_IMAGE_ARGS} \


### PR DESCRIPTION
The `kubenet` network plugin uses `ebtables` to set up some [dedup rules](https://github.com/kubernetes/kubernetes/blob/0480917b552be33e2dba47386e51decb1a211df6/pkg/kubelet/network/kubenet/kubenet_linux.go#L808). `ebtables` tries to automatically load missing `ebt_*` kernel modules when first used. Without access to `/lib/modules` this fails and `kubenet` subsequently fails to ensure the ebtables rules.

This PR replaces #2565 