### PR TITLE
profiles: Update btrfs-progs and dosfstools

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -39,6 +39,7 @@
 =sys-apps/smartmontools-6.4 **
 =sys-apps/util-linux-2.28.2 ~arm64
 =sys-block/parted-3.2-r1 ~arm64
+=sys-fs/btrfs-progs-4.10.2 ~arm64
 =sys-fs/cryptsetup-1.7.2 **
 =sys-fs/lsscsi-0.28 **
 =sys-fs/mdadm-3.4 **

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -42,10 +42,6 @@ dev-util/checkbashisms
 # Avoid cross compile error with amd64 stable (elfutils-0.158).
 =dev-libs/elfutils-0.161 ~amd64
 
-# newer btrfs-progs improve things like preserving capabilities in send/receive
-# https://github.com/coreos/bugs/issues/923
-=sys-fs/btrfs-progs-4.2.2 ~amd64 ~arm64
-
 # Get a newer version of pylint
 =dev-python/astng-0.21.1 ~amd64
 =dev-python/pylint-0.23.0 ~amd64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -85,3 +85,6 @@ dev-util/checkbashisms
 
 # CVE-2017-8779
 =net-nds/rpcbind-0.2.4-r1
+
+# Pick up fixes for bugs introduced in 4.0
+=sys-fs/dosfstools-4.1 **


### PR DESCRIPTION
Part of https://github.com/coreos/portage-stable/pull/553.