### PR TITLE
oem-gce: add ExecStop and rkt rm/stop

### DIFF
--- a/coreos-base/oem-gce/files/units/oem-gce.service
+++ b/coreos-base/oem-gce/files/units/oem-gce.service
@@ -11,6 +11,10 @@ RestartSec=5
 KillMode=process
 KillSignal=SIGTERM
 
+[Service]
+ExecStartPre=/usr/bin/mkdir --parents /var/lib/oem-gce
+ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/lib/oem-gce/coreos-oem-gce.uuid
+
 ExecStart=/usr/bin/rkt run \
     --inherit-env=true \
     --insecure-options=image \
@@ -19,9 +23,10 @@ ExecStart=/usr/bin/rkt run \
     --volume=etc,kind=host,source=/etc,readOnly=false \
     --volume=home,kind=host,source=/home,readOnly=false \
     --volume=runsystemd,kind=host,source=/run/systemd,readOnly=false \
+    --uuid-file-save=/var/lib/oem-gce/coreos-oem-gce.uuid \
     /usr/share/oem/coreos-oem-gce.aci
 
-ExecStopPost=/usr/bin/rkt gc --mark-only
+ExecStop=-/usr/bin/rkt stop --uuid-file=/var/lib/oem-gce/coreos-oem-gce.uuid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This copies the uuid-file-save and rkt rm/stop pattern from etcd-member.service.

Candidate fix for: https://github.com/coreos/bugs/issues/1989.

It is also probably still a problem that the container main process doesn't seem to respond correctly to SIGTERM, despite the comment:

> There is a custom main process that kills all of the contained services.

Let me know if it would be preferable to fix this that way instead.