### PR TITLE
profiles: enable Negotiate authentication in curl

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -20,6 +20,7 @@ media-libs/gd           png
 media-libs/libmtp       -crypt
 # We don't want any driver/hw rendering on the host
 media-sound/alsa-utils	-libsamplerate minimal
+net-misc/curl		kerberos
 net-misc/iputils	arping traceroute
 sci-geosciences/gpsd	-cxx
 sys-devel/gettext	-git


### PR DESCRIPTION
We are already installing `mit-krb5`, this just allows curl to authenticate with it.