### PR TITLE
coreos-base/oem-{cloudsigma,rackspace}: drop etcd.service drop-in

### DIFF
--- a/coreos-base/oem-cloudsigma/files/cloud-config.yml
+++ b/coreos-base/oem-cloudsigma/files/cloud-config.yml
@@ -2,14 +2,6 @@
 
 coreos:
   units:
-    - name: etcd.service
-      runtime: true
-      drop-ins:
-        - name: 10-oem.conf
-          content: |
-            [Service]
-            Environment=ETCD_PEER_ELECTION_TIMEOUT=1200
-
     - name: etcd2.service
       runtime: true
       drop-ins:

--- a/coreos-base/oem-rackspace/files/cloud-config.yml
+++ b/coreos-base/oem-rackspace/files/cloud-config.yml
@@ -2,14 +2,6 @@
 
 coreos:
   units:
-    - name: etcd.service
-      runtime: true
-      drop-ins:
-        - name: 10-oem.conf
-          content: |
-            [Service]
-            Environment=ETCD_PEER_ELECTION_TIMEOUT=1200
-
     - name: etcd2.service
       runtime: true
       drop-ins:


### PR DESCRIPTION
etcd v0 has been removed from Container Linux.