### PR TITLE
coreos-base: Add oem-vagrant-virtualbox

### DIFF
--- a/coreos-base/oem-vagrant-virtualbox/files/box/Vagrantfile
+++ b/coreos-base/oem-vagrant-virtualbox/files/box/Vagrantfile
@@ -1,0 +1,31 @@
+# -*- mode: ruby -*-
+# # vi: set ft=ruby :
+
+if Vagrant::VERSION < "1.6.0"
+  raise "Need at least vagrant version 1.6.0, please update"
+end
+
+require_relative 'change_host_name.rb'
+require_relative 'configure_networks.rb'
+require_relative 'base_mac.rb'
+
+Vagrant.configure("2") do |config|
+  # always use Vagrants insecure key
+  config.ssh.insert_key = false
+
+  # SSH in as the default 'core' user, it has the vagrant ssh key.
+  config.ssh.username = "core"
+
+  # Disable the base shared folder, guest additions are unavailable.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.provider :virtualbox do |vb|
+    # Guest Additions are unavailable.
+    vb.check_guest_additions = false
+    vb.functional_vboxsf = false
+
+    # Fix docker not being able to resolve private registry in VirtualBox
+    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+  end
+end

--- a/coreos-base/oem-vagrant-virtualbox/files/box/base_mac.rb
+++ b/coreos-base/oem-vagrant-virtualbox/files/box/base_mac.rb
@@ -1,0 +1,4 @@
+# This file must be rewritten with a real value for VirtualBox
+Vagrant.configure("2") do |config|
+  config.vm.base_mac = "080027000000"
+end

--- a/coreos-base/oem-vagrant-virtualbox/files/box/change_host_name.rb
+++ b/coreos-base/oem-vagrant-virtualbox/files/box/change_host_name.rb
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# # vi: set ft=ruby :
+
+# NOTE: This monkey-patching is done to disable to old cloud config based
+# change_host_name built into the upstream vagrant project
+
+require Vagrant.source_root.join("plugins/guests/coreos/cap/change_host_name.rb")
+
+module VagrantPlugins
+  module GuestCoreOS
+    module Cap
+      class ChangeHostName
+        def self.change_host_name(machine, name)
+        end
+      end
+    end
+  end
+end

--- a/coreos-base/oem-vagrant-virtualbox/files/box/configure_networks.rb
+++ b/coreos-base/oem-vagrant-virtualbox/files/box/configure_networks.rb
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# # vi: set ft=ruby :
+
+# NOTE: This monkey-patching is done to disable to old cloud config based
+# configure_networks built into the upstream vagrant project
+
+require Vagrant.source_root.join("plugins/guests/coreos/cap/configure_networks.rb")
+
+module VagrantPlugins
+  module GuestCoreOS
+    module Cap
+      class ConfigureNetworks
+        def self.configure_networks(machine, networks)
+        end
+      end
+    end
+  end
+end

--- a/coreos-base/oem-vagrant-virtualbox/files/grub.cfg
+++ b/coreos-base/oem-vagrant-virtualbox/files/grub.cfg
@@ -1,0 +1,3 @@
+# CoreOS GRUB settings
+
+set oem_id="virtualbox"

--- a/coreos-base/oem-vagrant-virtualbox/metadata.xml
+++ b/coreos-base/oem-vagrant-virtualbox/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-vagrant-virtualbox/oem-vagrant-virtualbox-0.0.1.ebuild
+++ b/coreos-base/oem-vagrant-virtualbox/oem-vagrant-virtualbox-0.0.1.ebuild
@@ -19,6 +19,4 @@ src_install() {
 	insinto "/usr/share/oem"
 	doins -r "${FILESDIR}/box"
 	doins "${FILESDIR}/grub.cfg"
-
-	into "/usr/share/oem"
 }

--- a/coreos-base/oem-vagrant-virtualbox/oem-vagrant-virtualbox-0.0.1.ebuild
+++ b/coreos-base/oem-vagrant-virtualbox/oem-vagrant-virtualbox-0.0.1.ebuild
@@ -1,0 +1,24 @@
+# Copyright 2013 The CoreOS Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+DESCRIPTION="OEM suite for vagrant images (virtualbox)"
+HOMEPAGE=""
+SRC_URI=""
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="amd64"
+IUSE=""
+
+# no source directory
+S="${WORKDIR}"
+
+src_install() {
+	insinto "/usr/share/oem"
+	doins -r "${FILESDIR}/box"
+	doins "${FILESDIR}/grub.cfg"
+
+	into "/usr/share/oem"
+}


### PR DESCRIPTION
This commit adds the new oem-vagrant-virtualbox provider, which is a
stripped down version of oem-vagrant for use with virtualbox and ignition.
It also sets the oem id to virtualbox instead of vagrant so it can be
handled correctly by ignition.