### PR TITLE
coreos-base: Add oem-virtualbox package

### DIFF
--- a/coreos-base/oem-virtualbox/files/grub.cfg
+++ b/coreos-base/oem-virtualbox/files/grub.cfg
@@ -1,0 +1,3 @@
+# CoreOS GRUB settings
+
+set oem_id="virtualbox"

--- a/coreos-base/oem-virtualbox/files/oem-release
+++ b/coreos-base/oem-virtualbox/files/oem-release
@@ -1,0 +1,4 @@
+ID=virtualbox
+VERSION_ID=@@OEM_VERSION_ID@@
+NAME="Oracle VirtualBox"
+BUG_REPORT_URL="https://issues.coreos.com"

--- a/coreos-base/oem-virtualbox/metadata.xml
+++ b/coreos-base/oem-virtualbox/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-virtualbox/oem-virtualbox-0.0.1.ebuild
+++ b/coreos-base/oem-virtualbox/oem-virtualbox-0.0.1.ebuild
@@ -1,0 +1,27 @@
+# Copyright (c) 2013 CoreOS, Inc.. All rights reserved.
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+DESCRIPTION="OEM suite for VirtualBox"
+HOMEPAGE=""
+SRC_URI=""
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="amd64"
+IUSE=""
+
+# no source directory
+S="${WORKDIR}"
+
+src_prepare() {
+	sed -e "s\\@@OEM_VERSION_ID@@\\${PVR}\\g" \
+		"${FILESDIR}/oem-release" > "${T}/oem-release" || die
+}
+
+src_install() {
+	insinto "/usr/share/oem"
+	doins "${FILESDIR}/grub.cfg"
+	doins "${T}/oem-release"
+}


### PR DESCRIPTION
This commit adds the oem-virtualbox package, which sets the id
in grub.cfg to "virtualbox" and creates an oem-release file
for virtualbox builds.