### PR TITLE
profiles: sync with Perl 5.24 on arm64

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -6,6 +6,7 @@
 =app-text/asciidoc-8.6.9-r3 ~arm64
 =dev-cpp/gflags-2.1.2 ~arm64
 =dev-cpp/glog-0.3.1 **
+=dev-lang/perl-5.24.1-r2 ~arm64
 =dev-libs/apr-util-1.5.4-r1 ~arm64
 =dev-libs/libevent-2.1.8 ~arm64
 =dev-libs/liblinear-210-r1 ~arm64
@@ -22,6 +23,7 @@
 =net-misc/bridge-utils-1.5 ~arm64
 =net-misc/iperf-3.1.3 **
 =net-nds/openldap-2.4.44 ~arm64
+=perl-core/File-Path-2.130.0 ~arm64
 =sys-apps/gptfdisk-1.0.1 ~arm64
 =sys-apps/i2c-tools-3.1.1-r1 ~arm64
 =sys-apps/lshw-02.17b-r2 **
@@ -35,4 +37,4 @@
 =sys-fs/mdadm-3.4 **
 =sys-fs/quota-4.02 **
 =sys-libs/libcap-ng-0.7.8 ~arm64
-=virtual/perl-Data-Dumper-2.158.0-r1 ~arm64
+=virtual/perl-File-Path-2.130.0 ~arm64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -69,9 +69,6 @@ dev-util/checkbashisms
 # systemd v233 requires libseccomp 2.3.1
 =sys-libs/libseccomp-2.3.1 **
 
-# perl 5.22.3-rc4 is stable and secure, but RCs break cross-compiling
-=dev-lang/perl-5.22.3 **
-
 # All versions are ~amd64 and not enabled on arm64
 =sys-apps/nvme-cli-1.1 **
 


### PR DESCRIPTION
The stable arm64 Perl ebuild is a version behind (as usual), so this bumps it for CVE-2017-6512.

Part of coreos/portage-stable#556.