### PR TITLE
coreos-base/coreos-metadata: use $COREOS_METADATA_OPT_PROVIDER for ssh

### DIFF
--- a/coreos-base/coreos-metadata/files/coreos-metadata-sshkeys@.service
+++ b/coreos-base/coreos-metadata/files/coreos-metadata-sshkeys@.service
@@ -3,7 +3,8 @@ Description=CoreOS Metadata Agent (SSH Keys)
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/coreos-metadata --cmdline --ssh-keys=%i
+Environment=COREOS_METADATA_OPT_PROVIDER=--cmdline
+ExecStart=/usr/bin/coreos-metadata ${COREOS_METADATA_OPT_PROVIDER} --ssh-keys=%i
 
 [Install]
 DefaultInstance=core


### PR DESCRIPTION
An earlier commit modified the coreos-metadata.service unit to use the
COREOS_METADATA_OPT_PROVIDER environment variable to specify the
provider for coreos-metadata. That commit failed to make the same change
to the coreos-metadata-sshkeys@.service unit. This commit fixes this.

Fixes https://github.com/coreos/bugs/issues/2014