### PR TITLE
oem-vagrant-virtualbox: change vagrant-virtualbox's oem-id to "vagrant-virtualbox"

### DIFF
--- a/coreos-base/oem-vagrant-virtualbox/files/grub.cfg
+++ b/coreos-base/oem-vagrant-virtualbox/files/grub.cfg
@@ -1,3 +1,3 @@
 # CoreOS GRUB settings
 
-set oem_id="virtualbox"
+set oem_id="vagrant-virtualbox"

--- a/coreos-base/oem-vagrant-virtualbox/oem-vagrant-virtualbox-0.0.2.ebuild
+++ b/coreos-base/oem-vagrant-virtualbox/oem-vagrant-virtualbox-0.0.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2013 The CoreOS Authors
+# Copyright 2017 The CoreOS Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5


### PR DESCRIPTION
This changes vagrant-virtualbox's oem-id from "virtualbox" to "vagrant-virtualbox"
to allow for more flexibility for this oem and add coreos-metadata support
for this oem.

Depends on https://github.com/coreos/ignition/pull/402