### PR TITLE
Profile cleanup

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -37,9 +37,6 @@ dev-util/checkbashisms
 # Avoid cross compile error with amd64 stable (elfutils-0.158).
 =dev-libs/elfutils-0.161 ~amd64
 
-# Get a newer version of pylint
-=dev-python/astng-0.21.1 ~amd64
-=dev-python/pylint-0.23.0 ~amd64
 =dev-python/pyusb-1.0.0 ~amd64
 
 =dev-lang/nasm-2.09.10 ~amd64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -39,8 +39,6 @@ dev-util/checkbashisms
 
 =dev-python/pyusb-1.0.0 ~amd64
 
-=dev-lang/nasm-2.09.10 ~amd64
-
 # Older versions of sssd fail to build
 =sys-auth/sssd-1.13.1 ~amd64 ~arm64
 

--- a/profiles/coreos/base/package.unmask
+++ b/profiles/coreos/base/package.unmask
@@ -1,7 +1,3 @@
-# masked upstream due to lua dep, but we don't enable lua support
-~net-analyzer/nmap-6.40
-
 # masked in portage-stable, but is unmasked in upstream.
 # remove this when upstream portage-stable package.mask is sync'd.
 =sys-block/open-iscsi-2.0.873
-


### PR DESCRIPTION
Drop a few obsolete version references noticed in coreos/portage-stable#569.