### PR TITLE
profiles: bump git

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -75,3 +75,6 @@ dev-util/checkbashisms
 
 # Pick up fixes for bugs introduced in 4.0
 =sys-fs/dosfstools-4.1 **
+
+# CVE-2017-1000117
+=dev-vcs/git-2.13.5

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -77,4 +77,4 @@ dev-util/checkbashisms
 =sys-fs/dosfstools-4.1 **
 
 # CVE-2017-1000117
-=dev-vcs/git-2.13.5
+=dev-vcs/git-2.14.1

--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -39,7 +39,7 @@ sys-apps/gptfdisk -icu
 dev-libs/apr-util -gdbm
 sys-libs/gdbm berkdb
 
-dev-vcs/git -perl -iconv
+dev-vcs/git -pcre-jit -perl -iconv
 
 net-analyzer/nmap ncat -lua
 


### PR DESCRIPTION
To allow a version patched for CVE-2017-1000117

Part of https://github.com/coreos/portage-stable/pull/571