### PR TITLE
profiles: bump git

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -80,3 +80,6 @@ dev-util/checkbashisms
 
 # Pick up fixes for bugs introduced in 4.0
 =sys-fs/dosfstools-4.1 **
+
+# CVE-2017-1000117
+=dev-vcs/git-2.13.5


### PR DESCRIPTION
Backport #2699 to alpha.

Part of coreos/portage-stable#574.