### PR TITLE
oem-vagrant-vmware: add oem-vagrant-vmware

### DIFF
--- a/coreos-base/oem-vagrant-vmware/README
+++ b/coreos-base/oem-vagrant-vmware/README
@@ -1,0 +1,1 @@
+The OEM version should match the current version of open-vm-tools.

--- a/coreos-base/oem-vagrant-vmware/files/box/Vagrantfile
+++ b/coreos-base/oem-vagrant-vmware/files/box/Vagrantfile
@@ -1,0 +1,29 @@
+# -*- mode: ruby -*-
+# # vi: set ft=ruby :
+
+if Vagrant::VERSION < "1.6.0"
+  raise "Need at least vagrant version 1.6.0, please update"
+end
+
+require_relative 'change_host_name.rb'
+require_relative 'configure_networks.rb'
+require_relative 'base_mac.rb'
+
+Vagrant.configure("2") do |config|
+  # always use Vagrants insecure key
+  config.ssh.insert_key = false
+
+  # SSH in as the default 'core' user, it has the vagrant ssh key.
+  config.ssh.username = "core"
+
+  # Disable the base shared folder, guest additions are unavailable.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+ ["vmware_fusion", "vmware_workstation"].each do |vmware|
+    config.vm.provider vmware do |v|
+      if v.respond_to?(:functional_hgfs=)
+        v.functional_hgfs = false
+      end
+    end
+  end
+end

--- a/coreos-base/oem-vagrant-vmware/files/box/base_mac.rb
+++ b/coreos-base/oem-vagrant-vmware/files/box/base_mac.rb
@@ -1,0 +1,4 @@
+# This file must be rewritten with a real value for VirtualBox
+Vagrant.configure("2") do |config|
+  config.vm.base_mac = "080027000000"
+end

--- a/coreos-base/oem-vagrant-vmware/files/box/change_host_name.rb
+++ b/coreos-base/oem-vagrant-vmware/files/box/change_host_name.rb
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# # vi: set ft=ruby :
+
+# NOTE: This monkey-patching is done to disable to old cloud config based
+# change_host_name built into the upstream vagrant project
+
+require Vagrant.source_root.join("plugins/guests/coreos/cap/change_host_name.rb")
+
+module VagrantPlugins
+  module GuestCoreOS
+    module Cap
+      class ChangeHostName
+        def self.change_host_name(machine, name)
+        end
+      end
+    end
+  end
+end

--- a/coreos-base/oem-vagrant-vmware/files/box/configure_networks.rb
+++ b/coreos-base/oem-vagrant-vmware/files/box/configure_networks.rb
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# # vi: set ft=ruby :
+
+# NOTE: This monkey-patching is done to disable to old cloud config based
+# configure_networks built into the upstream vagrant project
+
+require Vagrant.source_root.join("plugins/guests/coreos/cap/configure_networks.rb")
+
+module VagrantPlugins
+  module GuestCoreOS
+    module Cap
+      class ConfigureNetworks
+        def self.configure_networks(machine, networks)
+        end
+      end
+    end
+  end
+end

--- a/coreos-base/oem-vagrant-vmware/files/grub.cfg
+++ b/coreos-base/oem-vagrant-vmware/files/grub.cfg
@@ -1,0 +1,3 @@
+# CoreOS GRUB settings
+
+set oem_id="vmware"

--- a/coreos-base/oem-vagrant-vmware/files/units/vmtoolsd.service
+++ b/coreos-base/oem-vagrant-vmware/files/units/vmtoolsd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=VMware Tools Agent
+Documentation=https://github.com/vmware/open-vm-tools
+ConditionVirtualization=vmware
+
+[Service]
+ExecStartPre=/usr/bin/ln -sfT /usr/share/oem/vmware-tools /etc/vmware-tools
+ExecStart=/usr/share/oem/bin/vmtoolsd
+TimeoutStopSec=5
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/coreos-base/oem-vagrant-vmware/metadata.xml
+++ b/coreos-base/oem-vagrant-vmware/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/coreos-base/oem-vagrant-vmware/oem-vagrant-vmware-10.1.10.ebuild
+++ b/coreos-base/oem-vagrant-vmware/oem-vagrant-vmware-10.1.10.ebuild
@@ -1,0 +1,28 @@
+# Copyright 2017 The CoreOS Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+DESCRIPTION="OEM suite for vagrant images (vmware)"
+HOMEPAGE="https://github.com/coreos/coreos-overlay/tree/master/coreos-base"
+SRC_URI=""
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="amd64"
+IUSE=""
+
+DEPEND="
+	app-emulation/open-vm-tools
+	"
+RDEPEND="${DEPEND}"
+
+# no source directory
+S="${WORKDIR}"
+
+src_install() {
+	insinto "/usr/share/oem"
+	doins -r "${FILESDIR}/box"
+	doins "${FILESDIR}/grub.cfg"
+	doins -r "${FILESDIR}/units"
+}


### PR DESCRIPTION
This adds an oem-vagrant-vmware that removes the default cloud-config
and is designed to work with Ignition instead.