### PR TITLE
sys-kernel/coreos-{modules,kernel}: add debug symbols to /usr/lib/debug

### DIFF
--- a/sys-kernel/coreos-kernel/coreos-kernel-4.12.8-r1.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-4.12.8-r1.ebuild
@@ -77,9 +77,12 @@ src_install() {
 
 	insinto "/usr/lib/modules/${KV_FULL}/build"
 	doins build/System.map
-	# TODO: vmlinux would be useful for debugging but it is >300MB
 
-	# Uncomment vdso_install for easy access to debug symbols in gdb:
-	#   set debug-file-directory /lib/modules/4.0.7-coreos-r2/vdso/
-	#kmake INSTALL_MOD_PATH="${D}/usr" vdso_install
+	insinto "/usr/lib/debug/usr/boot"
+	newins build/vmlinux "vmlinux-${KV_FULL}"
+	dosym "../../../boot/vmlinux-${KV_FULL}" "/usr/lib/debug/usr/lib/modules/${KV_FULL}/vmlinux"
+
+	# For easy access to vdso debug symbols in gdb:
+	#   set debug-file-directory /usr/lib/debug/usr/lib/modules/${KV_FULL}/vdso/
+	kmake INSTALL_MOD_PATH="${D}/usr/lib/debug/usr" vdso_install
 }

--- a/sys-kernel/coreos-modules/coreos-modules-4.12.8-r1.ebuild
+++ b/sys-kernel/coreos-modules/coreos-modules-4.12.8-r1.ebuild
@@ -41,6 +41,13 @@ src_install() {
 		  INSTALL_FW_PATH="${T}/fw" \
 		  modules_install
 
+	# Install to /usr/lib/debug with debug symbols intact
+	kmake INSTALL_MOD_PATH="${D}/usr/lib/debug/usr" \
+		  INSTALL_FW_PATH="${T}/fw" \
+		  modules_install
+	rm "${D}/usr/lib/debug/usr/lib/modules/${KV_FULL}/"modules.* || die
+	rm "${D}/usr/lib/debug/usr/lib/modules/${KV_FULL}/"{source,build} || die
+
 	# Clean up the build tree
 	shred_keys
 	kmake clean


### PR DESCRIPTION
Add vmlinux, unstripped modules, and vdso binaries to `/usr/lib/debug` so they are available in the binpkgs.  This shouldn't affect the SDK or OS images, but costs about 350 MB of additional binpkg size.

Addresses https://github.com/coreos/bugs/issues/1243.