### PR TITLE
profiles: accept awscli for the sdk

### DIFF
--- a/profiles/coreos/targets/sdk/package.accept_keywords
+++ b/profiles/coreos/targets/sdk/package.accept_keywords
@@ -1,0 +1,4 @@
+# aws cli; handy for developer usage when working with kola
+dev-python/awscli ~amd64
+dev-python/s3transfer ~amd64
+dev-python/botocore ~amd64


### PR DESCRIPTION
Given our tooling, such as kola and ore, interacts with AWS, it's also
handy to have the awscli laying around to do things like emergency
cleanup, misc bash scripting, and other poking around.

This does add the yet-unused `profiles/coreos/targets/sdk/package.accept_keywords` file because that seemed like an appropriate place to accept the aws cli. Maybe there's a reason it wasn't used or that I should prefer something else?

Part of https://github.com/coreos/portage-stable/pull/580