### PR TITLE
profiles/coreos: accept newer tcpdump for arm

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -18,7 +18,7 @@
 =dev-util/re2c-0.16 ~arm64
 =dev-vcs/git-2.13.0 ~arm64
 =net-analyzer/nmap-7.40 ~arm64
-=net-analyzer/tcpdump-4.9.0 ~arm64
+=net-analyzer/tcpdump-4.9.2 ~arm64
 =net-dialup/minicom-2.7.1 ~arm64
 =net-firewall/ebtables-2.0.10.4-r1 ~arm64
 =net-firewall/ipset-6.29 ~arm64


### PR DESCRIPTION
Accompanies https://github.com/coreos/portage-stable/pull/584