### PR TITLE
coreos-base/oem-oracle-oci: add link-local iptables rules

### DIFF
--- a/coreos-base/oem-oracle-oci/files/iptables-rules
+++ b/coreos-base/oem-oracle-oci/files/iptables-rules
@@ -1,0 +1,16 @@
+# Loaded by oracle-oci-iptables.service
+*mangle
+:oracle-oci-link-local -
+-A oracle-oci-link-local -d 169.254.0.2/32 -p tcp -m owner --uid-owner 0 -m tcp --dport 3260 -m comment --comment "See the Oracle-Provided Images section in the Oracle Bare Metal documentation for security impact of modifying or removing this rule" -j ACCEPT
+-A oracle-oci-link-local -d 169.254.2.0/24 -p tcp -m owner --uid-owner 0 -m tcp --dport 3260 -m comment --comment "See the Oracle-Provided Images section in the Oracle Bare Metal documentation for security impact of modifying or removing this rule" -j ACCEPT
+-A oracle-oci-link-local -d 169.254.0.2/32 -p tcp -m tcp --dport 80 -m comment --comment "See the Oracle-Provided Images section in the Oracle Bare Metal documentation for security impact of modifying or removing this rule" -j ACCEPT
+-A oracle-oci-link-local -d 169.254.169.254/32 -p udp -m udp --dport 53 -m comment --comment "See the Oracle-Provided Images section in the Oracle Bare Metal documentation for security impact of modifying or removing this rule" -j ACCEPT
+-A oracle-oci-link-local -d 169.254.169.254/32 -p tcp -m tcp --dport 53 -m comment --comment "See the Oracle-Provided Images section in the Oracle Bare Metal documentation for security impact of modifying or removing this rule" -j ACCEPT
+-A oracle-oci-link-local -d 169.254.0.3/32 -p tcp -m owner --uid-owner 0 -m tcp --dport 80 -m comment --comment "See the Oracle-Provided Images section in the Oracle Bare Metal documentation for security impact of modifying or removing this rule" -j ACCEPT
+-A oracle-oci-link-local -d 169.254.0.4/32 -p tcp -m tcp --dport 80 -m comment --comment "See the Oracle-Provided Images section in the Oracle Bare Metal documentation for security impact of modifying or removing this rule" -j ACCEPT
+-A oracle-oci-link-local -d 169.254.169.254/32 -p tcp -m tcp --dport 80 -m comment --comment "See the Oracle-Provided Images section in the Oracle Bare Metal documentation for security impact of modifying or removing this rule" -j ACCEPT
+-A oracle-oci-link-local -d 169.254.169.254/32 -p udp -m udp --dport 67 -m comment --comment "See the Oracle-Provided Images section in the Oracle Bare Metal documentation for security impact of modifying or removing this rule" -j ACCEPT
+-A oracle-oci-link-local -d 169.254.169.254/32 -p udp -m udp --dport 69 -m comment --comment "See the Oracle-Provided Images section in the Oracle Bare Metal documentation for security impact of modifying or removing this rule" -j ACCEPT
+# REJECT unavailable in POSTROUTING
+-A oracle-oci-link-local -d 169.254.0.0/16 -m comment --comment "See the Oracle-Provided Images section in the Oracle Bare Metal documentation for security impact of modifying or removing this rule" -j DROP
+COMMIT

--- a/coreos-base/oem-oracle-oci/files/units/oracle-oci-iptables.service
+++ b/coreos-base/oem-oracle-oci/files/units/oracle-oci-iptables.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Oracle OCI Firewall Rules
+
+Before=network.target
+
+After=iptables-restore.service
+# Avoid races in case both are queued
+Before=iptables-save.service
+
+[Service]
+Type=oneshot
+# Load oracle-oci-link-local chain, overwriting any existing contents.
+# Invoke rules from mangle/POSTROUTING because fewer firewall tools are
+# likely to change it.
+ExecStart=/usr/sbin/iptables-restore --noflush /usr/share/oem/iptables-rules
+# Insert jump to link-local chain at beginning of mangle/POSTROUTING, only
+# if the existing ruleset doesn't have it.
+ExecStart=/bin/sh -c "/usr/sbin/iptables -t mangle -C POSTROUTING -d 169.254.0.0/16 -j oracle-oci-link-local 2>/dev/null || iptables -t mangle -I POSTROUTING 1 -d 169.254.0.0/16 -j oracle-oci-link-local"
+
+[Install]
+WantedBy=basic.target

--- a/coreos-base/oem-oracle-oci/oem-oracle-oci-0.2.0.ebuild
+++ b/coreos-base/oem-oracle-oci/oem-oracle-oci-0.2.0.ebuild
@@ -22,6 +22,7 @@ src_prepare() {
 src_install() {
 	insinto "/usr/share/oem"
 	doins "${FILESDIR}/grub.cfg"
+	doins "${FILESDIR}/iptables-rules"
 	doins "${T}/oem-release"
 	doins -r "${FILESDIR}/units"
 }


### PR DESCRIPTION
Prevent non-root users from accessing certain link-local services per [Oracle recommendation](https://docs.us-phoenix-1.oraclecloud.com/Content/Compute/References/bestpracticescompute.htm#two). Also apply filters to IP-forwarded virtual interfaces.