### PR TITLE
profiles: Sync libpcre on arm64 for GLSAs

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -14,6 +14,7 @@
 =dev-libs/libevent-2.1.8 ~arm64
 =dev-libs/liblinear-210-r1 ~arm64
 =dev-libs/libnl-3.2.27 ~arm64
+=dev-libs/libpcre-8.41 ~arm64
 =dev-libs/nss-3.29.5 ~arm64
 =dev-libs/userspace-rcu-0.9.1 **
 =dev-util/meson-0.40.1 **


### PR DESCRIPTION
Part of coreos/portage-stable#590