### PR TITLE
profiles: accept wget-1.19.1-r2 for arm64

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -33,6 +33,7 @@
 =net-misc/curl-7.55.1 ~arm64
 =net-misc/iperf-3.1.3 **
 =net-misc/socat-1.7.3.2 ~arm64
+=net-misc/wget-1.19.1-r2 ~arm64
 =net-nds/openldap-2.4.44 ~arm64
 =perl-core/File-Path-2.130.0 ~arm64
 =sys-apps/gptfdisk-1.0.1 ~arm64


### PR DESCRIPTION
Part of https://github.com/coreos/portage-stable/pull/595.  Fixes CVE-2017-13089 and CVE-2017-13090.