### PR TITLE
coreos-devel: add sdk-extras

### DIFF
--- a/coreos-devel/board-packages/board-packages-0.0.1.ebuild
+++ b/coreos-devel/board-packages/board-packages-0.0.1.ebuild
@@ -13,6 +13,10 @@ SLOT="0"
 KEYWORDS="amd64 arm64"
 IUSE=""
 
+# Depend on everything OEMs need, but not the OEMs themselves.
+# This makes the built packages available for image_vm_util.sh but
+# avoids copying the oem specific files (e.g. grub configs) before
+# the oem partition is set up.
 DEPEND=""
 RDEPEND="
 	amd64? (

--- a/coreos-devel/sdk-depends/sdk-depends-0.0.1.ebuild
+++ b/coreos-devel/sdk-depends/sdk-depends-0.0.1.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-DESCRIPTION="Meta ebuild for everything that should be in the SDK."
+DESCRIPTION="Meta ebuild for everything that needs to be in the SDK."
 HOMEPAGE="http://coreos.com/docs/sdk/"
 SRC_URI=""
 

--- a/coreos-devel/sdk-extras/sdk-extras-0.0.1.ebuild
+++ b/coreos-devel/sdk-extras/sdk-extras-0.0.1.ebuild
@@ -1,0 +1,45 @@
+# Copyright 2017 The CoreOS Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# This isn't meant to be installed directly. It mostly exists so we can better keep track of
+# dependencies within the SDK.
+
+EAPI=5
+
+DESCRIPTION="Meta ebuild for everything that isn't needed in the SDK, but might be useful"
+HOMEPAGE="http://coreos.com/docs/sdk/"
+SRC_URI=""
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="amd64"
+IUSE=""
+
+RDEPEND="
+	app-admin/python-updater
+	app-backup/casync
+	app-crypt/efitools
+	app-crypt/tpm-tools
+	app-editors/emacs
+	app-editors/nano
+	app-portage/eix
+	app-portage/gentoolkit-dev
+	app-portage/repoman
+	app-misc/screen
+	app-misc/tmux
+	app-text/tree
+	app-text/dos2unix
+	dev-util/cscope
+	dev-util/perf
+	dev-util/strace
+	dev-util/valgrind
+	dev-go/glide
+	dev-go/godep
+	dev-python/awscli
+	sys-apps/ed
+"
+
+# Needed for Jenkins
+RDEPEND+="
+	dev-util/catalyst
+"

--- a/profiles/coreos/targets/sdk/package.accept_keywords
+++ b/profiles/coreos/targets/sdk/package.accept_keywords
@@ -7,3 +7,7 @@ dev-python/botocore ~amd64
 dev-lang/rust ~amd64
 dev-util/cargo ~amd64
 virtual/rust ~amd64
+
+# Accept go utilities
+dev-go/glide ~amd64
+dev-go/godep ~amd64


### PR DESCRIPTION
Add a metapackage like `sdk-depends` to track useful things we want in portage-stable or coreos-overlay, but aren't actually required for building an image. This list is currently incomplete.

The end goal is for every package in `coreos-overlay` or `portage-stable` to be in, or be a dependency of something in `board-packages`, `sdk-depends`, or `sdk-extras`. This will make maintainence of those repos easier. 