### PR TITLE
profiles/arm64: remove ref to udev-init-scripts

### DIFF
--- a/profiles/coreos/arm64/package.use.force
+++ b/profiles/coreos/arm64/package.use.force
@@ -1,3 +1,2 @@
 sys-auth/polkit -introspection
 sys-apps/systemd -introspection
-sys-fs/udev-init-scripts -introspection


### PR DESCRIPTION
We do not use udev-init-scripts. Remove configuration for it.

cc @glevand: this was added in b37d1376cd13290ea708bd2e8a17dcce5e87064a. Do you know why? Were we including that package then?