### PR TITLE
profiles: add -nls for man-db

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -103,3 +103,6 @@ dev-db/etcd -etcdctl
 # can be removed with socat-2.0.0; this is the openssl/readline license
 # incompatibility 
 net-misc/socat -ssl
+
+# Prevent pulling in a ton of perl dependencies
+sys-apps/man-db -nls


### PR DESCRIPTION
This will enable us to emerge man-db without pulling in a ton of perl
dependencies. This means we can also switch to only having one man
provider.