### PR TITLE
profiles: Bump libxml2 on arm64 for a GLSA

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -15,6 +15,7 @@
 =dev-libs/liblinear-210-r1 ~arm64
 =dev-libs/libnl-3.2.27 ~arm64
 =dev-libs/libpcre-8.41 ~arm64
+=dev-libs/libxml2-2.9.4-r3 ~arm64
 =dev-libs/nss-3.29.5 ~arm64
 =dev-libs/userspace-rcu-0.9.1 **
 =dev-util/meson-0.40.1 **


### PR DESCRIPTION
Part of coreos/portage-stable#614