### PR TITLE
net-fs/nfs-utils: fix rpcbind race

### DIFF
--- a/net-fs/nfs-utils/files/nfs-utils-1.3.2-rpcbind-after.patch
+++ b/net-fs/nfs-utils/files/nfs-utils-1.3.2-rpcbind-after.patch
@@ -1,0 +1,18 @@
+Fixed in 2.2.1 commit 907426b00bdcd69d9a56ac1870990e8ae8c6fe9f
+use rpcbind.target instead of .socket (as the upstream commit uses)
+because the future versions of nfs-server.service activate the socket
+while ours activate the service.
+
+diff --git a/systemd/nfs-mountd.service b/systemd/nfs-mountd.service
+index d908afe..587112b 100644
+--- a/systemd/nfs-mountd.service
++++ b/systemd/nfs-mountd.service
+@@ -3,6 +3,7 @@ Description=NFS Mount Daemon
+ Requires=proc-fs-nfsd.mount
+ After=proc-fs-nfsd.mount
+ After=network.target
++After=rpcbind.target
+ BindsTo=nfs-server.service
+ 
+ Wants=nfs-config.service
+

--- a/net-fs/nfs-utils/nfs-utils-1.3.2-r11.ebuild
+++ b/net-fs/nfs-utils/nfs-utils-1.3.2-r11.ebuild
@@ -59,6 +59,7 @@ src_prepare() {
 	epatch "${FILESDIR}"/${PN}-1.1.4-mtab-sym.patch
 	epatch "${FILESDIR}"/${PN}-1.2.8-cross-build.patch
 	epatch "${FILESDIR}"/${PN}-1.3.2-background-statd.patch
+	epatch "${FILESDIR}"/${PN}-1.3.2-rpcbind-after.patch
 
 	sed \
 		-e "/^sbindir/s:= := \"${EPREFIX}\":g" \


### PR DESCRIPTION
Make rpcbind an After= for nfs-mountd. This is fixed upstream but
hasn't been marked as stable on amd64/arm64 by gentoo. Should fix the
nfs races in kola tests.