### PR TITLE
profiles: Sync the multipath-tools version on arm64

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -50,6 +50,7 @@
 =sys-fs/cryptsetup-1.7.4 **
 =sys-fs/lsscsi-0.28 ~arm64
 =sys-fs/mdadm-3.4 **
+=sys-fs/multipath-tools-0.6.4-r1 ~arm64
 =sys-fs/quota-4.02 **
 =sys-libs/binutils-libs-2.28.1 ~arm64
 =sys-libs/libcap-ng-0.7.8 ~arm64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -41,9 +41,6 @@ dev-util/checkbashisms
 # mtools 4.0.18 has '-i' flag for working with images
 =sys-fs/mtools-4.0.18
 
-# multipath-tools 0.6.2 fixes systemd dependencies
-=sys-fs/multipath-tools-0.6.2-r2
-
 # flex 2.6.1 breaks cross-compiling, but 2.6.3 adds a configure workaround
 =sys-devel/flex-2.6.3 **
 


### PR DESCRIPTION
Part of coreos/portage-stable#629