### PR TITLE
sys-kernel/coreos-sources: Backport IPSec performance fix to 4.13

### DIFF
--- a/sys-kernel/coreos-kernel/coreos-kernel-4.13.16-r3.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-4.13.16-r3.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION="-r2"
+COREOS_SOURCE_REVISION="-r3"
 inherit coreos-kernel
 
 DESCRIPTION="CoreOS Linux kernel"

--- a/sys-kernel/coreos-modules/coreos-modules-4.13.16-r3.ebuild
+++ b/sys-kernel/coreos-modules/coreos-modules-4.13.16-r3.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION="-r2"
+COREOS_SOURCE_REVISION="-r3"
 inherit coreos-kernel savedconfig
 
 DESCRIPTION="CoreOS Linux kernel modules"

--- a/sys-kernel/coreos-sources/coreos-sources-4.13.16-r3.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-4.13.16-r3.ebuild
@@ -59,4 +59,5 @@ UNIPATCH_LIST="
 	${PATCH_DIR}/z0026-scsi-mptsas-Fixup-device-hotplug-for-VMWare-ESXi.patch \
 	${PATCH_DIR}/z0027-KVM-Remove-I-O-port-0x80-bypass-on-intel-hosts.patch \
 	${PATCH_DIR}/z0028-dccp-CVE-2017-8824-use-after-free-in-DCCP-code.patch \
+	${PATCH_DIR}/z0029-xfrm-Fix-GSO-for-IPsec-with-GRE-tunnel.patch \
 "

--- a/sys-kernel/coreos-sources/files/4.13/z0001-efi-Add-EFI_SECURE_BOOT-bit.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0001-efi-Add-EFI_SECURE_BOOT-bit.patch
@@ -1,7 +1,7 @@
 From cb530cc0018d1bc325a03afcd94005a2f09c8447 Mon Sep 17 00:00:00 2001
 From: Josh Boyer <jwboyer@fedoraproject.org>
 Date: Mon, 21 Nov 2016 23:55:55 +0000
-Subject: [PATCH 01/28] efi: Add EFI_SECURE_BOOT bit
+Subject: [PATCH 01/29] efi: Add EFI_SECURE_BOOT bit
 
 UEFI machines can be booted in Secure Boot mode.  Add a EFI_SECURE_BOOT bit
 that can be passed to efi_enabled() to find out whether secure boot is
@@ -42,5 +42,5 @@ index 8269bcb8ccf7..7952dd3ffa73 100644
  #ifdef CONFIG_EFI
  /*
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0002-Add-the-ability-to-lock-down-access-to-the-running-k.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0002-Add-the-ability-to-lock-down-access-to-the-running-k.patch
@@ -1,7 +1,7 @@
 From fad03831bb23e8396209ca5502f12c65905d7343 Mon Sep 17 00:00:00 2001
 From: David Howells <dhowells@redhat.com>
 Date: Mon, 21 Nov 2016 23:36:17 +0000
-Subject: [PATCH 02/28] Add the ability to lock down access to the running
+Subject: [PATCH 02/29] Add the ability to lock down access to the running
  kernel image
 
 Provide a single call to allow kernel code to determine whether the system
@@ -145,5 +145,5 @@ index 000000000000..5788c60ff4e1
 +}
 +EXPORT_SYMBOL(kernel_is_locked_down);
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0003-efi-Lock-down-the-kernel-if-booted-in-secure-boot-mo.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0003-efi-Lock-down-the-kernel-if-booted-in-secure-boot-mo.patch
@@ -1,7 +1,7 @@
 From 768d6504a3651557f584f01f49ce27d635d02aba Mon Sep 17 00:00:00 2001
 From: David Howells <dhowells@redhat.com>
 Date: Mon, 21 Nov 2016 23:55:55 +0000
-Subject: [PATCH 03/28] efi: Lock down the kernel if booted in secure boot mode
+Subject: [PATCH 03/29] efi: Lock down the kernel if booted in secure boot mode
 
 UEFI Secure Boot provides a mechanism for ensuring that the firmware will
 only load signed bootloaders and kernels.  Certain use cases may also
@@ -65,5 +65,5 @@ index 319995f58345..d0128aef43ce 100644
  		default:
  			pr_info("Secure boot could not be determined\n");
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0004-Enforce-module-signatures-if-the-kernel-is-locked-do.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0004-Enforce-module-signatures-if-the-kernel-is-locked-do.patch
@@ -1,7 +1,7 @@
 From 4a7e6f15571c0a8bef25aab29a06e9e93fb1c398 Mon Sep 17 00:00:00 2001
 From: David Howells <dhowells@redhat.com>
 Date: Wed, 23 Nov 2016 13:22:22 +0000
-Subject: [PATCH 04/28] Enforce module signatures if the kernel is locked down
+Subject: [PATCH 04/29] Enforce module signatures if the kernel is locked down
 
 If the kernel is locked down, require that all modules have valid
 signatures that we can verify.
@@ -25,5 +25,5 @@ index 40f983cbea81..e5b878b26906 100644
  
  	return err;
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0005-Restrict-dev-mem-and-dev-kmem-when-the-kernel-is-loc.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0005-Restrict-dev-mem-and-dev-kmem-when-the-kernel-is-loc.patch
@@ -1,7 +1,7 @@
 From d41b819e8cec32c2de8e90dea2e7f521fd3caa84 Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <matthew.garrett@nebula.com>
 Date: Tue, 22 Nov 2016 08:46:16 +0000
-Subject: [PATCH 05/28] Restrict /dev/mem and /dev/kmem when the kernel is
+Subject: [PATCH 05/29] Restrict /dev/mem and /dev/kmem when the kernel is
  locked down
 
 Allowing users to write to address space makes it possible for the kernel to
@@ -39,5 +39,5 @@ index 593a8818aca9..ba68add9677f 100644
  		unsigned long to_write = min_t(unsigned long, count,
  					       (unsigned long)high_memory - p);
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0006-kexec-Disable-at-runtime-if-the-kernel-is-locked-dow.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0006-kexec-Disable-at-runtime-if-the-kernel-is-locked-dow.patch
@@ -1,7 +1,7 @@
 From df3982a2e00f15069529219a699a584687377f0a Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <matthew.garrett@nebula.com>
 Date: Tue, 22 Nov 2016 08:46:15 +0000
-Subject: [PATCH 06/28] kexec: Disable at runtime if the kernel is locked down
+Subject: [PATCH 06/29] kexec: Disable at runtime if the kernel is locked down
 
 kexec permits the loading and execution of arbitrary code in ring 0, which
 is something that lock-down is meant to prevent. It makes sense to disable
@@ -20,20 +20,20 @@ diff --git a/kernel/kexec.c b/kernel/kexec.c
 index e62ec4dc6620..37f75d0b75de 100644
 --- a/kernel/kexec.c
 +++ b/kernel/kexec.c
-@@ -202,6 +202,13 @@ SYSCALL_DEFINE4(kexec_load, unsigned long, entry, unsigned long, nr_segments,
+@@ -201,6 +201,13 @@ SYSCALL_DEFINE4(kexec_load, unsigned long, entry, unsigned long, nr_segments,
+ 	if (!capable(CAP_SYS_BOOT) || kexec_load_disabled)
  		return -EPERM;
  
- 	/*
++	/*
 +	 * kexec can be used to circumvent module loading restrictions, so
 +	 * prevent loading in that case
 +	 */
 +	if (kernel_is_locked_down())
 +		return -EPERM;
 +
-+	/*
+ 	/*
  	 * Verify we have a legal set of flags
  	 * This leaves us room for future extensions.
- 	 */
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0007-Copy-secure_boot-flag-in-boot-params-across-kexec-re.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0007-Copy-secure_boot-flag-in-boot-params-across-kexec-re.patch
@@ -1,7 +1,7 @@
 From 4592e414e362ea4796b4dff52f1bd8b4ac87ff05 Mon Sep 17 00:00:00 2001
 From: Dave Young <dyoung@redhat.com>
 Date: Tue, 22 Nov 2016 08:46:15 +0000
-Subject: [PATCH 07/28] Copy secure_boot flag in boot params across kexec
+Subject: [PATCH 07/29] Copy secure_boot flag in boot params across kexec
  reboot
 
 Kexec reboot in case secure boot being enabled does not keep the secure
@@ -34,5 +34,5 @@ index fb095ba0c02f..7d0fac5bcbbe 100644
  	ei->efi_systab = current_ei->efi_systab;
  	ei->efi_systab_hi = current_ei->efi_systab_hi;
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0008-kexec_file-Disable-at-runtime-if-securelevel-has-bee.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0008-kexec_file-Disable-at-runtime-if-securelevel-has-bee.patch
@@ -1,7 +1,7 @@
 From ccb08e72e27639b8818e54b908c3026bb79bd8ad Mon Sep 17 00:00:00 2001
 From: "Lee, Chun-Yi" <joeyli.kernel@gmail.com>
 Date: Wed, 23 Nov 2016 13:49:19 +0000
-Subject: [PATCH 08/28] kexec_file: Disable at runtime if securelevel has been
+Subject: [PATCH 08/29] kexec_file: Disable at runtime if securelevel has been
  set
 
 When KEXEC_VERIFY_SIG is not enabled, kernel should not loads image
@@ -35,5 +35,5 @@ index 9f48f4412297..7da87007c202 100644
  	if (flags != (flags & KEXEC_FILE_FLAGS))
  		return -EINVAL;
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0009-hibernate-Disable-when-the-kernel-is-locked-down.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0009-hibernate-Disable-when-the-kernel-is-locked-down.patch
@@ -1,7 +1,7 @@
 From ac0f92a8fd6adafef754a8e1fde320c426493844 Mon Sep 17 00:00:00 2001
 From: Josh Boyer <jwboyer@fedoraproject.org>
 Date: Tue, 22 Nov 2016 08:46:15 +0000
-Subject: [PATCH 09/28] hibernate: Disable when the kernel is locked down
+Subject: [PATCH 09/29] hibernate: Disable when the kernel is locked down
 
 There is currently no way to verify the resume image when returning
 from hibernate.  This might compromise the signed modules trust model,
@@ -28,5 +28,5 @@ index e1914c7b85b1..7859ba79e181 100644
  
  /**
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0010-uswsusp-Disable-when-the-kernel-is-locked-down.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0010-uswsusp-Disable-when-the-kernel-is-locked-down.patch
@@ -1,7 +1,7 @@
 From 1223e45efef77e13238e2b806e5dbf19b2bb4c9d Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <mjg59@srcf.ucam.org>
 Date: Wed, 23 Nov 2016 13:28:17 +0000
-Subject: [PATCH 10/28] uswsusp: Disable when the kernel is locked down
+Subject: [PATCH 10/29] uswsusp: Disable when the kernel is locked down
 
 uswsusp allows a user process to dump and then restore kernel state, which
 makes it possible to modify the running kernel.  Disable this if the kernel
@@ -28,5 +28,5 @@ index 22df9f7ff672..e4b926d329b7 100644
  
  	if (!atomic_add_unless(&snapshot_device_available, -1, 0)) {
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0011-PCI-Lock-down-BAR-access-when-the-kernel-is-locked-d.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0011-PCI-Lock-down-BAR-access-when-the-kernel-is-locked-d.patch
@@ -1,7 +1,7 @@
 From caf58edf10b8705b67260be44e8722e04e0beef7 Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <matthew.garrett@nebula.com>
 Date: Tue, 22 Nov 2016 08:46:15 +0000
-Subject: [PATCH 11/28] PCI: Lock down BAR access when the kernel is locked
+Subject: [PATCH 11/29] PCI: Lock down BAR access when the kernel is locked
  down
 
 Any hardware that can potentially generate DMA has to be locked down in
@@ -99,5 +99,5 @@ index 9bf993e1f71e..c09524738ceb 100644
  
  	dev = pci_get_bus_and_slot(bus, dfn);
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0012-x86-Lock-down-IO-port-access-when-the-kernel-is-lock.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0012-x86-Lock-down-IO-port-access-when-the-kernel-is-lock.patch
@@ -1,7 +1,7 @@
 From 6b4d4c8fc3ebc2c734d1e735292f7b4808f9aba5 Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <matthew.garrett@nebula.com>
 Date: Tue, 22 Nov 2016 08:46:16 +0000
-Subject: [PATCH 12/28] x86: Lock down IO port access when the kernel is locked
+Subject: [PATCH 12/29] x86: Lock down IO port access when the kernel is locked
  down
 
 IO port access would permit users to gain access to PCI configuration
@@ -55,5 +55,5 @@ index ba68add9677f..5e2a260fb89f 100644
  }
  
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0013-x86-Restrict-MSR-access-when-the-kernel-is-locked-do.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0013-x86-Restrict-MSR-access-when-the-kernel-is-locked-do.patch
@@ -1,7 +1,7 @@
 From e65fa22a0a08f9b8790a409be7a3f3631746480b Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <matthew.garrett@nebula.com>
 Date: Tue, 22 Nov 2016 08:46:17 +0000
-Subject: [PATCH 13/28] x86: Restrict MSR access when the kernel is locked down
+Subject: [PATCH 13/29] x86: Restrict MSR access when the kernel is locked down
 
 Writing to MSRs should not be allowed if the kernel is locked down, since
 it could lead to execution of arbitrary code in kernel mode.  Based on a
@@ -40,5 +40,5 @@ index ef688804f80d..fbcce028e502 100644
  			err = -EFAULT;
  			break;
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0014-asus-wmi-Restrict-debugfs-interface-when-the-kernel-.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0014-asus-wmi-Restrict-debugfs-interface-when-the-kernel-.patch
@@ -1,7 +1,7 @@
 From 71ab13860ced57f89aecde34e42fb21238ae00e8 Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <matthew.garrett@nebula.com>
 Date: Tue, 22 Nov 2016 08:46:16 +0000
-Subject: [PATCH 14/28] asus-wmi: Restrict debugfs interface when the kernel is
+Subject: [PATCH 14/29] asus-wmi: Restrict debugfs interface when the kernel is
  locked down
 
 We have no way of validating what all of the Asus WMI methods do on a given
@@ -51,5 +51,5 @@ index 709e3a67391a..2d8db47698b2 100644
  				     1, asus->debug.method_id,
  				     &input, &output);
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0015-ACPI-Limit-access-to-custom_method-when-the-kernel-i.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0015-ACPI-Limit-access-to-custom_method-when-the-kernel-i.patch
@@ -1,7 +1,7 @@
 From 1cd3b669e50fb0a8070dd0e0a63c04c675dd2f6c Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <matthew.garrett@nebula.com>
 Date: Tue, 22 Nov 2016 08:46:16 +0000
-Subject: [PATCH 15/28] ACPI: Limit access to custom_method when the kernel is
+Subject: [PATCH 15/29] ACPI: Limit access to custom_method when the kernel is
  locked down
 
 custom_method effectively allows arbitrary access to system memory, making
@@ -29,5 +29,5 @@ index c68e72414a67..e4d721c330c0 100644
  		/* parse the table header to get the table length */
  		if (count <= sizeof(struct acpi_table_header))
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0016-acpi-Ignore-acpi_rsdp-kernel-param-when-the-kernel-h.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0016-acpi-Ignore-acpi_rsdp-kernel-param-when-the-kernel-h.patch
@@ -1,7 +1,7 @@
 From 51a12724dc171b45c066c69c3a1496faa863d856 Mon Sep 17 00:00:00 2001
 From: Josh Boyer <jwboyer@redhat.com>
 Date: Tue, 22 Nov 2016 08:46:16 +0000
-Subject: [PATCH 16/28] acpi: Ignore acpi_rsdp kernel param when the kernel has
+Subject: [PATCH 16/29] acpi: Ignore acpi_rsdp kernel param when the kernel has
  been locked down
 
 This option allows userspace to pass the RSDP address to the kernel, which
@@ -28,5 +28,5 @@ index db78d353bab1..d4d4ba348451 100644
  #endif
  
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0017-acpi-Disable-ACPI-table-override-if-the-kernel-is-lo.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0017-acpi-Disable-ACPI-table-override-if-the-kernel-is-lo.patch
@@ -1,7 +1,7 @@
 From 79b14b97f1ba37fd185855864aef4e9de788cf1c Mon Sep 17 00:00:00 2001
 From: Linn Crosetto <linn@hpe.com>
 Date: Wed, 23 Nov 2016 13:32:27 +0000
-Subject: [PATCH 17/28] acpi: Disable ACPI table override if the kernel is
+Subject: [PATCH 17/29] acpi: Disable ACPI table override if the kernel is
  locked down
 
 From the kernel documentation (initrd_table_override.txt):
@@ -37,5 +37,5 @@ index ff425390bfa8..c72bfa97888a 100644
  		memblock_find_in_range(0, ACPI_TABLE_UPGRADE_MAX_PHYS,
  				       all_tables_size, PAGE_SIZE);
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0018-acpi-Disable-APEI-error-injection-if-the-kernel-is-l.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0018-acpi-Disable-APEI-error-injection-if-the-kernel-is-l.patch
@@ -1,7 +1,7 @@
 From 3f9fdfd73964aede8d8b0a6778c88ac397ab103f Mon Sep 17 00:00:00 2001
 From: Linn Crosetto <linn@hpe.com>
 Date: Wed, 23 Nov 2016 13:39:41 +0000
-Subject: [PATCH 18/28] acpi: Disable APEI error injection if the kernel is
+Subject: [PATCH 18/29] acpi: Disable APEI error injection if the kernel is
  locked down
 
 ACPI provides an error injection mechanism, EINJ, for debugging and testing
@@ -40,5 +40,5 @@ index ec50c32ea3da..e082718d01c2 100644
  	if (flags && (flags &
  		~(SETWA_FLAGS_APICID|SETWA_FLAGS_MEM|SETWA_FLAGS_PCIE_SBDF)))
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0019-bpf-Restrict-kernel-image-access-functions-when-the-.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0019-bpf-Restrict-kernel-image-access-functions-when-the-.patch
@@ -1,7 +1,7 @@
 From 1ad7533c31e6de9e93d3d64c9eabdc13faaf2292 Mon Sep 17 00:00:00 2001
 From: "Lee, Chun-Yi" <jlee@suse.com>
 Date: Wed, 23 Nov 2016 13:52:16 +0000
-Subject: [PATCH 19/28] bpf: Restrict kernel image access functions when the
+Subject: [PATCH 19/29] bpf: Restrict kernel image access functions when the
  kernel is locked down
 
 There are some bpf functions can be used to read kernel memory:
@@ -53,5 +53,5 @@ index dc498b605d5d..fb240222b89b 100644
  	for (i = 0; i < fmt_size; i++) {
  		if ((!isprint(fmt[i]) && !isspace(fmt[i])) || !isascii(fmt[i]))
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0020-scsi-Lock-down-the-eata-driver.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0020-scsi-Lock-down-the-eata-driver.patch
@@ -1,7 +1,7 @@
 From d15faaedd550b271eb6342991d7f87d302398743 Mon Sep 17 00:00:00 2001
 From: David Howells <dhowells@redhat.com>
 Date: Tue, 22 Nov 2016 10:10:34 +0000
-Subject: [PATCH 20/28] scsi: Lock down the eata driver
+Subject: [PATCH 20/29] scsi: Lock down the eata driver
 
 When the kernel is running in secure boot mode, we lock down the kernel to
 prevent userspace from modifying the running kernel image.  Whilst this
@@ -43,5 +43,5 @@ index 227dd2c2ec2f..5c036d10c18b 100644
  #if defined(MODULE)
  	/* io_port could have been modified when loading as a module */
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0021-Prohibit-PCMCIA-CIS-storage-when-the-kernel-is-locke.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0021-Prohibit-PCMCIA-CIS-storage-when-the-kernel-is-locke.patch
@@ -1,7 +1,7 @@
 From d820b80eade47a1b78f6fe2d3f87b5c17295ad27 Mon Sep 17 00:00:00 2001
 From: David Howells <dhowells@redhat.com>
 Date: Fri, 25 Nov 2016 14:37:45 +0000
-Subject: [PATCH 21/28] Prohibit PCMCIA CIS storage when the kernel is locked
+Subject: [PATCH 21/29] Prohibit PCMCIA CIS storage when the kernel is locked
  down
 
 Prohibit replacement of the PCMCIA Card Information Structure when the
@@ -29,5 +29,5 @@ index 55ef7d1fd8da..193e4f7b73b1 100644
  
  	if (off)
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0022-Lock-down-TIOCSSERIAL.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0022-Lock-down-TIOCSSERIAL.patch
@@ -1,7 +1,7 @@
 From b4f01f10ecb275a8bbb6982f94b975aaa0b272cd Mon Sep 17 00:00:00 2001
 From: David Howells <dhowells@redhat.com>
 Date: Wed, 7 Dec 2016 10:28:39 +0000
-Subject: [PATCH 22/28] Lock down TIOCSSERIAL
+Subject: [PATCH 22/29] Lock down TIOCSSERIAL
 
 Lock down TIOCSSERIAL as that can be used to change the ioport and irq
 settings on a serial port.  This only appears to be an issue for the serial
@@ -32,5 +32,5 @@ index f534a40aebde..e32c0179f423 100644
  		retval = -EPERM;
  		if (change_irq || change_port ||
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0023-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0023-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch
@@ -1,7 +1,7 @@
 From 6dc637a3e36191477f882e45a6e88f98f42818f3 Mon Sep 17 00:00:00 2001
 From: Vito Caputo <vito.caputo@coreos.com>
 Date: Wed, 25 Nov 2015 02:59:45 -0800
-Subject: [PATCH 23/28] kbuild: derive relative path for KBUILD_SRC from CURDIR
+Subject: [PATCH 23/29] kbuild: derive relative path for KBUILD_SRC from CURDIR
 
 This enables relocating source and build trees to different roots,
 provided they stay reachable relative to one another.  Useful for
@@ -26,5 +26,5 @@ index bc9a897e0431..125887d6336c 100644
  
  # Leave processing to above invocation of make
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0024-Add-arm64-coreos-verity-hash.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0024-Add-arm64-coreos-verity-hash.patch
@@ -1,7 +1,7 @@
 From f15db8d7c3c5f00db92c5207cb2c40cd178cf65b Mon Sep 17 00:00:00 2001
 From: Geoff Levand <geoff@infradead.org>
 Date: Fri, 11 Nov 2016 17:28:52 -0800
-Subject: [PATCH 24/28] Add arm64 coreos verity hash
+Subject: [PATCH 24/29] Add arm64 coreos verity hash
 
 Signed-off-by: Geoff Levand <geoff@infradead.org>
 ---
@@ -25,5 +25,5 @@ index 613fc3000677..fdaf86c78332 100644
  	/*
  	 * The debug table is referenced via its Relative Virtual Address (RVA),
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0025-mm-thp-Do-not-make-page-table-dirty-unconditionally-.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0025-mm-thp-Do-not-make-page-table-dirty-unconditionally-.patch
@@ -1,7 +1,7 @@
 From 8a44a968daec0911bc28e26e8926f402a07dcb2b Mon Sep 17 00:00:00 2001
 From: "Kirill A. Shutemov" <kirill.shutemov@linux.intel.com>
 Date: Mon, 27 Nov 2017 06:21:25 +0300
-Subject: [PATCH 25/28] mm, thp: Do not make page table dirty unconditionally
+Subject: [PATCH 25/29] mm, thp: Do not make page table dirty unconditionally
  in touch_p[mu]d()
 
 Currently, we unconditionally make page table dirty in touch_pmd().
@@ -104,5 +104,5 @@ index 90731e3b7e58..8b887db33383 100644
  		/*
  		 * We don't mlock() pte-mapped THPs. This way we can avoid
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0026-scsi-mptsas-Fixup-device-hotplug-for-VMWare-ESXi.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0026-scsi-mptsas-Fixup-device-hotplug-for-VMWare-ESXi.patch
@@ -1,7 +1,7 @@
 From f75d35638db500bba6d0e2418cf3a8a09dae2652 Mon Sep 17 00:00:00 2001
 From: Hannes Reinecke <hare@suse.de>
 Date: Thu, 24 Aug 2017 14:52:43 +0200
-Subject: [PATCH 26/28] scsi: mptsas: Fixup device hotplug for VMWare ESXi
+Subject: [PATCH 26/29] scsi: mptsas: Fixup device hotplug for VMWare ESXi
 
 VMWare ESXi emulates an mptsas HBA, but exposes all drives as
 direct-attached SAS drives.  This it not how the driver originally
@@ -39,5 +39,5 @@ index f6308ad35b19..42ee70c23d9f 100644
  				__func__, __LINE__, sas_device.handle_parent));
  			port_info = mptsas_find_portinfo_by_handle(ioc,
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0027-KVM-Remove-I-O-port-0x80-bypass-on-intel-hosts.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0027-KVM-Remove-I-O-port-0x80-bypass-on-intel-hosts.patch
@@ -1,7 +1,7 @@
 From ba2997a798be2de4a6b5d91da8789913790cb776 Mon Sep 17 00:00:00 2001
 From: Andrew Honig <ahonig@google.com>
 Date: Wed, 29 Nov 2017 10:54:24 -0800
-Subject: [PATCH 27/28] KVM: Remove I/O port 0x80 bypass on intel hosts.
+Subject: [PATCH 27/29] KVM: Remove I/O port 0x80 bypass on intel hosts.
 
 KVM allows guests to directly access I/O port 0x80 on intel hosts.  If
 the guest floods this port with writes it generates exceptions and
@@ -77,5 +77,5 @@ index 118709e7597d..67a4deca43e8 100644
  	memset(vmx_msr_bitmap_legacy, 0xff, PAGE_SIZE);
  	memset(vmx_msr_bitmap_longmode, 0xff, PAGE_SIZE);
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0028-dccp-CVE-2017-8824-use-after-free-in-DCCP-code.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0028-dccp-CVE-2017-8824-use-after-free-in-DCCP-code.patch
@@ -1,7 +1,7 @@
 From 1ba144bf0eeeebcafba3bcc6cf98c74c2c3ead73 Mon Sep 17 00:00:00 2001
 From: Mohamed Ghannam <simo.ghannam@gmail.com>
 Date: Tue, 5 Dec 2017 12:23:04 -0800
-Subject: [PATCH 28/28] dccp: CVE-2017-8824: use-after-free in DCCP code
+Subject: [PATCH 28/29] dccp: CVE-2017-8824: use-after-free in DCCP code
 
 Whenever the sock object is in DCCP_CLOSED state, dccp_disconnect()
 must free dccps_hc_tx_ccid and dccps_hc_rx_ccid and set to NULL.
@@ -36,5 +36,5 @@ index b68168fcc06a..9d43c1f40274 100644
  	__skb_queue_purge(&sk->sk_receive_queue);
  	__skb_queue_purge(&sk->sk_write_queue);
 -- 
-2.13.6
+2.14.3
 

--- a/sys-kernel/coreos-sources/files/4.13/z0029-xfrm-Fix-GSO-for-IPsec-with-GRE-tunnel.patch
+++ b/sys-kernel/coreos-sources/files/4.13/z0029-xfrm-Fix-GSO-for-IPsec-with-GRE-tunnel.patch
@@ -1,0 +1,44 @@
+From 9290f7e9ed1dc3302cba413eb8215eb1e14d8dc0 Mon Sep 17 00:00:00 2001
+From: Steffen Klassert <steffen.klassert@secunet.com>
+Date: Mon, 30 Oct 2017 10:04:04 +0100
+Subject: [PATCH 29/29] xfrm: Fix GSO for IPsec with GRE tunnel.
+
+We reset the encapsulation field of the skb too early
+in xfrm_output. As a result, the GRE GSO handler does
+not segment the packets. This leads to a performance
+drop down. We fix this by resetting the encapsulation
+field right before we do the transformation, when
+the inner headers become invalid.
+
+Fixes: f1bd7d659ef0 ("xfrm: Add encapsulation header offsets while SKB is not encrypted")
+Reported-by: Vicente De Luca <vdeluca@zendesk.com>
+Signed-off-by: Steffen Klassert <steffen.klassert@secunet.com>
+---
+ net/xfrm/xfrm_output.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/net/xfrm/xfrm_output.c b/net/xfrm/xfrm_output.c
+index 8c0b6722aaa8..626424645030 100644
+--- a/net/xfrm/xfrm_output.c
++++ b/net/xfrm/xfrm_output.c
+@@ -102,6 +102,9 @@ static int xfrm_output_one(struct sk_buff *skb, int err)
+ 		if (xfrm_offload(skb)) {
+ 			x->type_offload->encap(x, skb);
+ 		} else {
++			/* Inner headers are invalid now. */
++			skb->encapsulation = 0;
++
+ 			err = x->type->output(x, skb);
+ 			if (err == -EINPROGRESS)
+ 				goto out;
+@@ -205,7 +208,6 @@ int xfrm_output(struct sock *sk, struct sk_buff *skb)
+ 	int err;
+ 
+ 	secpath_reset(skb);
+-	skb->encapsulation = 0;
+ 
+ 	if (xfrm_dev_offload_ok(skb, x)) {
+ 		struct sec_path *sp;
+-- 
+2.14.3
+


### PR DESCRIPTION
coreos/bugs#2294