### PR TITLE
sys-kernel/coreos-sources: make sure sync-check.sh is executable (1632)

### DIFF
--- a/sys-kernel/coreos-kernel/coreos-kernel-4.14.7-r1.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-4.14.7-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION=""
+COREOS_SOURCE_REVISION="-r1"
 inherit coreos-kernel
 
 DESCRIPTION="CoreOS Linux kernel"

--- a/sys-kernel/coreos-modules/coreos-modules-4.14.7-r1.ebuild
+++ b/sys-kernel/coreos-modules/coreos-modules-4.14.7-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION=""
+COREOS_SOURCE_REVISION="-r1"
 inherit coreos-kernel savedconfig
 
 DESCRIPTION="CoreOS Linux kernel modules"

--- a/sys-kernel/coreos-sources/coreos-sources-4.14.7-r1.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-4.14.7-r1.ebuild
@@ -26,6 +26,16 @@ fi
 KEYWORDS="amd64 arm64"
 IUSE=""
 
+# For 4.14 >= 4.14.10
+src_install() {
+	kernel-2_src_install
+	local r="${PR#r0}"
+	local script="${ED}/usr/src/linux-${PV/_rc/-rc}-coreos${r:+-${r}}/tools/objtool/sync-check.sh"
+	if [[ -e "${script}" ]]; then
+		chmod +x "${script}" || die
+	fi
+}
+
 # XXX: Note we must prefix the patch filenames with "z" to ensure they are
 # applied _after_ a potential patch-${KV}.patch file, present when building a
 # patchlevel revision.  We mustn't apply our patches first, it fails when the


### PR DESCRIPTION
GNU patch apparently doesn't set permissions when creating files.