### PR TITLE
app-emulation/rkt: update systemd required for host stage1

### DIFF
--- a/app-emulation/rkt/rkt-9999.ebuild
+++ b/app-emulation/rkt/rkt-9999.ebuild
@@ -55,7 +55,7 @@ DEPEND="app-arch/cpio
 	${COMMON_DEPEND}"
 RDEPEND="!app-emulation/rocket
 	rkt_stage1_host? (
-		~sys-apps/systemd-222
+		>=sys-apps/systemd-220
 		app-shells/bash
 	)
 	${COMMON_DEPEND}"


### PR DESCRIPTION
As it is now it doesn't build because we ship systemd 236.

Update the version needed to >= 220, which is what rkt needs [[1]].

[1]: https://github.com/rkt/rkt/blob/v1.29.0/stage1/init/init.go#L417