### PR TITLE
net-misc/google-cloud-sdk: depend on pyopenssl

### DIFF
--- a/net-misc/google-cloud-sdk/google-cloud-sdk-138.0.0-r1.ebuild
+++ b/net-misc/google-cloud-sdk/google-cloud-sdk-138.0.0-r1.ebuild
@@ -22,6 +22,7 @@ S="${WORKDIR}/${PN}"
 DEPEND="${PYTHON_DEPS}"
 RDEPEND="${DEPEND}
 	dev-python/crcmod[${PYTHON_USEDEP}]
+	dev-python/pyopenssl
 	!net-misc/gsutil"
 
 src_prepare() {


### PR DESCRIPTION
pyopenssl is needed for gsutil signurl.

Depends on https://github.com/coreos/portage-stable/pull/644