### PR TITLE
app-emulation/containerd: Fix the 1.0.* manifest entries

### DIFF
--- a/app-emulation/containerd/containerd-1.0.0.ebuild
+++ b/app-emulation/containerd/containerd-1.0.0.ebuild
@@ -11,11 +11,13 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_REPO_URI="https://${GITHUB_URI}.git"
 	inherit git-r3
 else
-	EGIT_COMMIT="89623f28b87a6004d4b785663257362d1658a729" # v1.0.0
+	MY_PV="${PV/_rc/-rc.}"
+	EGIT_COMMIT="v${MY_PV}"
+	CONTAINERD_COMMIT="89623f2"
 	SRC_URI="https://${GITHUB_URI}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="amd64 arm64"
 	inherit vcs-snapshot
-	MAKE_VERSION_ARGS="REVISION=${EGIT_COMMIT} VERSION=v${PV}"
+	MAKE_VERSION_ARGS="REVISION=${CONTAINERD_COMMIT} VERSION=v${PV}"
 fi
 
 inherit coreos-go systemd

--- a/app-emulation/containerd/containerd-9999.ebuild
+++ b/app-emulation/containerd/containerd-9999.ebuild
@@ -11,7 +11,9 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_REPO_URI="https://${GITHUB_URI}.git"
 	inherit git-r3
 else
-	EGIT_COMMIT="9b55aab90508bd389d7654c4baf173a981477d55" # v1.0.1
+	MY_PV="${PV/_rc/-rc.}"
+	EGIT_COMMIT="v${MY_PV}"
+	CONTAINERD_COMMIT="9b55aab"
 	SRC_URI="https://${GITHUB_URI}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="amd64 arm64"
 	inherit vcs-snapshot
@@ -41,7 +43,7 @@ src_prepare() {
 	default
 	if [[ ${PV} != *9999* ]]; then
 		sed -i -e "s/git describe --match.*$/echo ${PV})/"\
-			-e "s/git rev-parse HEAD.*$/echo ${EGIT_COMMIT})/"\
+			-e "s/git rev-parse HEAD.*$/echo $CONTAINERD_COMMIT)/"\
 			-e "s/-s -w//" \
 			Makefile || die
 	fi


### PR DESCRIPTION
The old entries were for the release archives, which apparently worked at one point, since they're the versions that were downloaded into our source mirror.  This changes the entries to use the commit archives instead, which just have different parent directories.