### PR TITLE
app-emulation/containerd: Fix GOARCH build problem

### DIFF
--- a/app-emulation/containerd/containerd-9999.ebuild
+++ b/app-emulation/containerd/containerd-9999.ebuild
@@ -40,7 +40,7 @@ src_unpack() {
 }
 
 src_prepare() {
-	default
+	coreos-go_src_prepare
 	if [[ ${PV} != *9999* ]]; then
 		sed -i -e "s/git describe --match.*$/echo ${PV})/"\
 			-e "s/git rev-parse HEAD.*$/echo $CONTAINERD_COMMIT)/"\


### PR DESCRIPTION
A call to coreos-go_src_prepare in src_prepare will get go_export called, which exports the correct GOARCH value.

Fixes https://github.com/coreos/bugs/issues/2366 (torcx store has archives of wrong arch).
