### PR TITLE
app-emulation/containerd: Specify the full commit SHA-1

### DIFF
--- a/app-emulation/containerd/containerd-1.0.0.ebuild
+++ b/app-emulation/containerd/containerd-1.0.0.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == *9999 ]]; then
 else
 	MY_PV="${PV/_rc/-rc.}"
 	EGIT_COMMIT="v${MY_PV}"
-	CONTAINERD_COMMIT="89623f2"
+	CONTAINERD_COMMIT="89623f28b87a6004d4b785663257362d1658a729"
 	SRC_URI="https://${GITHUB_URI}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="amd64 arm64"
 	inherit vcs-snapshot

--- a/app-emulation/containerd/containerd-9999.ebuild
+++ b/app-emulation/containerd/containerd-9999.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == *9999 ]]; then
 else
 	MY_PV="${PV/_rc/-rc.}"
 	EGIT_COMMIT="v${MY_PV}"
-	CONTAINERD_COMMIT="9b55aab"
+	CONTAINERD_COMMIT="9b55aab90508bd389d7654c4baf173a981477d55"
 	SRC_URI="https://${GITHUB_URI}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="amd64 arm64"
 	inherit vcs-snapshot


### PR DESCRIPTION
The Docker tests won't match an abbreviated commit ID.