### PR TITLE
profiles: Disable ccache for SDK packages

### DIFF
--- a/profiles/coreos/targets/sdk/make.defaults
+++ b/profiles/coreos/targets/sdk/make.defaults
@@ -12,3 +12,6 @@ QEMU_SOFTMMU_TARGETS="x86_64 i386 aarch64"
 
 # For cross build support.
 QEMU_USER_TARGETS="aarch64"
+
+# Disable ccache in the SDK so it stops randomly breaking catalyst.
+FEATURES="-ccache"


### PR DESCRIPTION
This profile is used by catalyst when building toolchains packages, which randomly fail from ccache permissions problems after certain releases.

An alternative solution is to create a separate profile just for catalyst, but that doesn't seem necessary given that there aren't many SDK packages that would benefit from this caching that aren't able to be tested on the amd64-usr board, which still has ccache.

Part of coreos/scripts#795