### PR TITLE
Fix containerd 1.0.1 cross-compilation in beta

### DIFF
--- a/app-emulation/containerd/containerd-9999.ebuild
+++ b/app-emulation/containerd/containerd-9999.ebuild
@@ -38,7 +38,7 @@ src_unpack() {
 }
 
 src_prepare() {
-	default
+	coreos-go_src_prepare
 	if [[ ${PV} != *9999* ]]; then
 		sed -i -e "s/git describe --match.*$/echo ${PV})/"\
 			-e "s/git rev-parse HEAD.*$/echo ${EGIT_COMMIT})/"\


### PR DESCRIPTION
Previously, containerd 1.0.1 was never built in beta so this wasn't needed, but since the Docker 17.12.1 LTS release was backported, it updated containerd to the affected version.

Backports #3084