### PR TITLE
dev-libs/openssl: enable ec algorithms

### DIFF
--- a/dev-libs/openssl/openssl-1.0.2n-r1.ebuild
+++ b/dev-libs/openssl/openssl-1.0.2n-r1.ebuild
@@ -138,6 +138,7 @@ multilib_src_configure() {
 		${sslout} \
 		$(use cpu_flags_x86_sse2 || echo "no-sse2") \
 		enable-camellia \
+		enable-ec \
 		${ec_nistp_64_gcc_128} \
 		enable-idea \
 		enable-mdc2 \


### PR DESCRIPTION
They were mistakenly disabled by
d128c85ef4a1be6ea400fc41ae8c861fe1aa62c3. Newer versions of bind-tools
need this.

now with ebuild bump