### PR TITLE
profiles: Drop obsolete util-linux entry

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -65,9 +65,6 @@ dev-util/checkbashisms
 # https://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git/commit/?id=d6a4076b6ba6547d7e52c377a7c58c56eb5ea16e
 =sys-apps/iproute2-4.13.0 ~amd64 ~arm64
 
-# systemd v235 requires util-linux 2.30
-=sys-apps/util-linux-2.30.2 ~amd64 ~arm64
-
 # Upgrade to GCC 7.3 for retpoline support.
 =sys-devel/gcc-7.3.0
 =cross-aarch64-cros-linux-gnu/gcc-7.3.0 ~arm64


### PR DESCRIPTION
Part of coreos/portage-stable#649