### PR TITLE
profiles: Accept the fixed Intel microcode for Spectre mitigation

### DIFF
--- a/profiles/coreos/amd64/package.mask
+++ b/profiles/coreos/amd64/package.mask
@@ -1,1 +1,0 @@
->=sys-firmware/intel-microcode-20180100

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -69,3 +69,6 @@ dev-util/checkbashisms
 =sys-devel/gcc-7.3.0
 =cross-aarch64-cros-linux-gnu/gcc-7.3.0 ~arm64
 =cross-x86_64-cros-linux-gnu/gcc-7.3.0 ~amd64
+
+# Accept the fixed Intel microcode for Spectre mitigation.
+=sys-firmware/intel-microcode-20180312 ~amd64


### PR DESCRIPTION
Part of coreos/portage-stable#650