### PR TITLE
profiles/coreos: update gnupg use flags

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -4,7 +4,6 @@
 =app-admin/sudo-1.8.20_p2 ~arm64
 =app-arch/bzip2-1.0.6-r8 ~arm64
 =app-arch/libarchive-3.3.1 ~arm64
-=app-crypt/gnupg-2.2.4 ~arm64
 =app-crypt/mit-krb5-1.14.2 ~arm64
 =app-text/asciidoc-8.6.9-r3 ~arm64
 =dev-cpp/gflags-2.1.2 ~arm64
@@ -17,6 +16,7 @@
 =dev-libs/liblinear-210-r1 ~arm64
 =dev-libs/libnl-3.2.27 ~arm64
 =dev-libs/libpcre-8.41 ~arm64
+=dev-libs/libusb-1.0.21 ~arm64
 =dev-libs/libxml2-2.9.4-r3 ~arm64
 =dev-libs/nss-3.29.5 ~arm64
 =dev-libs/libpcre2-10.30 ~arm64
@@ -59,4 +59,5 @@
 =sys-libs/binutils-libs-2.29.1-r1 ~arm64
 =sys-libs/libcap-ng-0.7.8 ~arm64
 =virtual/libudev-232 ~arm64
+=virtual/libusb-1-r2 ~arm64
 =virtual/perl-File-Path-2.130.0 ~arm64

--- a/profiles/coreos/base/package.use.mask
+++ b/profiles/coreos/base/package.use.mask
@@ -1,5 +1,5 @@
 # We don't ship GnuTLS by default, and smartcard has a dep loop
-app-crypt/gnupg gnutls smartcard
+app-crypt/gnupg smartcard ssl
 
 # We don't need integration with cvs, perl, or subversion in git, so we can
 dev-vcs/git cvs perl subversion

--- a/profiles/coreos/targets/sdk/package.use
+++ b/profiles/coreos/targets/sdk/package.use
@@ -5,6 +5,9 @@ dev-vcs/git pcre
 dev-util/catalyst ccache
 dev-lang/python sqlite
 
+# Allow smartcard support in the SDK for image signing
+app-crypt/gnupg smartcard usb
+
 # for qemu
 app-arch/bzip2 static-libs
 app-emulation/qemu static-user


### PR DESCRIPTION
Goes along with https://github.com/coreos/portage-stable/pull/651

Newer versions of gnupg have an 'ssl' use flag, which is effectively the
same as the gnutls flag we already disabled.

This PR also enables 'usb' in addition to 'smartcard' for the sdk. Some
smartcards are also usb devices.