### PR TITLE
profiles: Drop special handling of intel-microcode

### DIFF
--- a/profiles/coreos/amd64/package.mask
+++ b/profiles/coreos/amd64/package.mask
@@ -1,1 +1,0 @@
->=sys-firmware/intel-microcode-20180100


### PR DESCRIPTION
This is for upgrading Intel's microcode to the Spectre-mitigating version in beta.

Part of coreos/portage-stable#652