### PR TITLE
profiles: Drop special handling of intel-microcode

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -69,6 +69,3 @@ dev-util/checkbashisms
 =sys-devel/gcc-7.3.0
 =cross-aarch64-cros-linux-gnu/gcc-7.3.0 ~arm64
 =cross-x86_64-cros-linux-gnu/gcc-7.3.0 ~amd64
-
-# Accept the fixed Intel microcode for Spectre mitigation.
-=sys-firmware/intel-microcode-20180312 ~amd64


### PR DESCRIPTION
This isn't really necessary, but it syncs master with the newer change in beta.

Part of coreos/portage-stable#653