### PR TITLE
NFS Kerberos support

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -94,3 +94,7 @@ net-misc/socat -ssl
 
 # Prevent pulling in a ton of perl dependencies
 sys-apps/man-db -nls
+
+#Add nfs kerberos support
+net-fs/nfs-utils kerberos nfsv41
+net-libs/libtirpc kerberos


### PR DESCRIPTION
This patch enable nfs kerberos support in coreos.
The add of compile options don't pull any new package, just enable the build of rpc.gssd binary used by kerberos.

