### PR TITLE
sys-kernel/coreos-*: fix oops with vxlan

### DIFF
--- a/sys-kernel/coreos-kernel/coreos-kernel-4.14.30-r1.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-4.14.30-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION=""
+COREOS_SOURCE_REVISION="-r1"
 inherit coreos-kernel
 
 DESCRIPTION="CoreOS Linux kernel"

--- a/sys-kernel/coreos-modules/coreos-modules-4.14.30-r1.ebuild
+++ b/sys-kernel/coreos-modules/coreos-modules-4.14.30-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION=""
+COREOS_SOURCE_REVISION="-r1"
 inherit coreos-kernel savedconfig
 
 DESCRIPTION="CoreOS Linux kernel modules"

--- a/sys-kernel/coreos-sources/coreos-sources-4.14.30-r1.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-4.14.30-r1.ebuild
@@ -36,4 +36,5 @@ UNIPATCH_LIST="
 	${PATCH_DIR}/z0003-block-factor-out-__blkdev_issue_zero_pages.patch \
 	${PATCH_DIR}/z0004-block-cope-with-WRITE-ZEROES-failing-in-blkdev_issue.patch \
 	${PATCH_DIR}/z0005-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch \
+	${PATCH_DIR}/z0006-net-don-t-call-update_pmtu-unconditionally.patch \
 "

--- a/sys-kernel/coreos-sources/files/4.14/z0001-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch
+++ b/sys-kernel/coreos-sources/files/4.14/z0001-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch
@@ -1,7 +1,7 @@
 From babc36f144eb99319c578570bd6664f76cebc49a Mon Sep 17 00:00:00 2001
 From: Vito Caputo <vito.caputo@coreos.com>
 Date: Wed, 25 Nov 2015 02:59:45 -0800
-Subject: [PATCH 1/5] kbuild: derive relative path for KBUILD_SRC from CURDIR
+Subject: [PATCH 1/6] kbuild: derive relative path for KBUILD_SRC from CURDIR
 
 This enables relocating source and build trees to different roots,
 provided they stay reachable relative to one another.  Useful for
@@ -26,5 +26,5 @@ index 29fc3c91f3e4..f8ec79955f43 100644
  
  # Leave processing to above invocation of make
 -- 
-2.14.3
+2.13.6
 

--- a/sys-kernel/coreos-sources/files/4.14/z0002-Add-arm64-coreos-verity-hash.patch
+++ b/sys-kernel/coreos-sources/files/4.14/z0002-Add-arm64-coreos-verity-hash.patch
@@ -1,7 +1,7 @@
 From 0a47e041d2260e6da954812dcec22f51c74e3645 Mon Sep 17 00:00:00 2001
 From: Geoff Levand <geoff@infradead.org>
 Date: Fri, 11 Nov 2016 17:28:52 -0800
-Subject: [PATCH 2/5] Add arm64 coreos verity hash
+Subject: [PATCH 2/6] Add arm64 coreos verity hash
 
 Signed-off-by: Geoff Levand <geoff@infradead.org>
 ---
@@ -25,5 +25,5 @@ index 613fc3000677..fdaf86c78332 100644
  	/*
  	 * The debug table is referenced via its Relative Virtual Address (RVA),
 -- 
-2.14.3
+2.13.6
 

--- a/sys-kernel/coreos-sources/files/4.14/z0003-block-factor-out-__blkdev_issue_zero_pages.patch
+++ b/sys-kernel/coreos-sources/files/4.14/z0003-block-factor-out-__blkdev_issue_zero_pages.patch
@@ -1,7 +1,7 @@
 From e558bcc7e6af6595fbbdde01158567752d9988e4 Mon Sep 17 00:00:00 2001
 From: Ilya Dryomov <idryomov@gmail.com>
 Date: Mon, 16 Oct 2017 15:59:09 +0200
-Subject: [PATCH 3/5] block: factor out __blkdev_issue_zero_pages()
+Subject: [PATCH 3/6] block: factor out __blkdev_issue_zero_pages()
 
 blkdev_issue_zeroout() will use this in !BLKDEV_ZERO_NOFALLBACK case.
 
@@ -103,5 +103,5 @@ index 63fb971d6574..9e86a4871b0f 100644
  EXPORT_SYMBOL(__blkdev_issue_zeroout);
  
 -- 
-2.14.3
+2.13.6
 

--- a/sys-kernel/coreos-sources/files/4.14/z0004-block-cope-with-WRITE-ZEROES-failing-in-blkdev_issue.patch
+++ b/sys-kernel/coreos-sources/files/4.14/z0004-block-cope-with-WRITE-ZEROES-failing-in-blkdev_issue.patch
@@ -1,7 +1,7 @@
 From 70fb36baf0009b8d183b1622e22f66b7da16d63a Mon Sep 17 00:00:00 2001
 From: Ilya Dryomov <idryomov@gmail.com>
 Date: Mon, 16 Oct 2017 15:59:10 +0200
-Subject: [PATCH 4/5] block: cope with WRITE ZEROES failing in
+Subject: [PATCH 4/6] block: cope with WRITE ZEROES failing in
  blkdev_issue_zeroout()
 
 sd_config_write_same() ignores ->max_ws_blocks == 0 and resets it to
@@ -106,5 +106,5 @@ index 9e86a4871b0f..2bc544ce3d2e 100644
  	return ret;
  }
 -- 
-2.14.3
+2.13.6
 

--- a/sys-kernel/coreos-sources/files/4.14/z0005-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch
+++ b/sys-kernel/coreos-sources/files/4.14/z0005-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch
@@ -1,7 +1,7 @@
 From 055c189bc61cc6a8fd75d4d8704ae651656b589e Mon Sep 17 00:00:00 2001
 From: David Michael <david.michael@coreos.com>
 Date: Thu, 8 Feb 2018 21:23:12 -0500
-Subject: [PATCH 5/5] tools/objtool/Makefile: Don't fail on fallthrough with
+Subject: [PATCH 5/6] tools/objtool/Makefile: Don't fail on fallthrough with
  new GCCs
 
 ---
@@ -23,5 +23,5 @@ index 95563b8e1ad7..307652c42a7b 100644
  
  CFLAGS += -I$(srctree)/tools/include/
 -- 
-2.14.3
+2.13.6
 

--- a/sys-kernel/coreos-sources/files/4.14/z0006-net-don-t-call-update_pmtu-unconditionally.patch
+++ b/sys-kernel/coreos-sources/files/4.14/z0006-net-don-t-call-update_pmtu-unconditionally.patch
@@ -1,0 +1,166 @@
+From f5f2102a531988e24f19a13fdc5b8206007aaad5 Mon Sep 17 00:00:00 2001
+From: Nicolas Dichtel <nicolas.dichtel@6wind.com>
+Date: Thu, 25 Jan 2018 19:03:03 +0100
+Subject: [PATCH 6/6] net: don't call update_pmtu unconditionally
+
+Commit f15ca723c1ebe6c1a06bc95fda6b62cd87b44559 upstream.
+
+Some dst_ops (e.g. md_dst_ops)) doesn't set this handler. It may result to:
+"BUG: unable to handle kernel NULL pointer dereference at           (null)"
+
+Let's add a helper to check if update_pmtu is available before calling it.
+
+Fixes: 52a589d51f10 ("geneve: update skb dst pmtu on tx path")
+Fixes: a93bf0ff4490 ("vxlan: update skb dst pmtu on tx path")
+CC: Roman Kapl <code@rkapl.cz>
+CC: Xin Long <lucien.xin@gmail.com>
+Signed-off-by: Nicolas Dichtel <nicolas.dichtel@6wind.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+Signed-off-by: Benjamin Gilbert <bgilbert@redhat.com>
+---
+ drivers/infiniband/ulp/ipoib/ipoib_cm.c | 3 +--
+ drivers/net/vxlan.c                     | 6 ++----
+ include/net/dst.h                       | 8 ++++++++
+ net/ipv4/ip_tunnel.c                    | 3 +--
+ net/ipv4/ip_vti.c                       | 2 +-
+ net/ipv6/ip6_tunnel.c                   | 5 ++---
+ net/ipv6/ip6_vti.c                      | 2 +-
+ net/ipv6/sit.c                          | 4 ++--
+ 8 files changed, 18 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/infiniband/ulp/ipoib/ipoib_cm.c b/drivers/infiniband/ulp/ipoib/ipoib_cm.c
+index 7774654c2ccb..7a5ed5a5391e 100644
+--- a/drivers/infiniband/ulp/ipoib/ipoib_cm.c
++++ b/drivers/infiniband/ulp/ipoib/ipoib_cm.c
+@@ -1447,8 +1447,7 @@ void ipoib_cm_skb_too_long(struct net_device *dev, struct sk_buff *skb,
+ 	struct ipoib_dev_priv *priv = ipoib_priv(dev);
+ 	int e = skb_queue_empty(&priv->cm.skb_queue);
+ 
+-	if (skb_dst(skb))
+-		skb_dst(skb)->ops->update_pmtu(skb_dst(skb), NULL, skb, mtu);
++	skb_dst_update_pmtu(skb, mtu);
+ 
+ 	skb_queue_tail(&priv->cm.skb_queue, skb);
+ 	if (e)
+diff --git a/drivers/net/vxlan.c b/drivers/net/vxlan.c
+index bb44f0c6891f..3d9c5b35a4a7 100644
+--- a/drivers/net/vxlan.c
++++ b/drivers/net/vxlan.c
+@@ -2158,8 +2158,7 @@ static void vxlan_xmit_one(struct sk_buff *skb, struct net_device *dev,
+ 		if (skb_dst(skb)) {
+ 			int mtu = dst_mtu(ndst) - VXLAN_HEADROOM;
+ 
+-			skb_dst(skb)->ops->update_pmtu(skb_dst(skb), NULL,
+-						       skb, mtu);
++			skb_dst_update_pmtu(skb, mtu);
+ 		}
+ 
+ 		tos = ip_tunnel_ecn_encap(tos, old_iph, skb);
+@@ -2200,8 +2199,7 @@ static void vxlan_xmit_one(struct sk_buff *skb, struct net_device *dev,
+ 		if (skb_dst(skb)) {
+ 			int mtu = dst_mtu(ndst) - VXLAN6_HEADROOM;
+ 
+-			skb_dst(skb)->ops->update_pmtu(skb_dst(skb), NULL,
+-						       skb, mtu);
++			skb_dst_update_pmtu(skb, mtu);
+ 		}
+ 
+ 		tos = ip_tunnel_ecn_encap(tos, old_iph, skb);
+diff --git a/include/net/dst.h b/include/net/dst.h
+index 694c2e6ae618..ebfb4328fdb1 100644
+--- a/include/net/dst.h
++++ b/include/net/dst.h
+@@ -520,4 +520,12 @@ static inline struct xfrm_state *dst_xfrm(const struct dst_entry *dst)
+ }
+ #endif
+ 
++static inline void skb_dst_update_pmtu(struct sk_buff *skb, u32 mtu)
++{
++	struct dst_entry *dst = skb_dst(skb);
++
++	if (dst && dst->ops->update_pmtu)
++		dst->ops->update_pmtu(dst, NULL, skb, mtu);
++}
++
+ #endif /* _NET_DST_H */
+diff --git a/net/ipv4/ip_tunnel.c b/net/ipv4/ip_tunnel.c
+index 4e90082b23a6..29ee155ebf51 100644
+--- a/net/ipv4/ip_tunnel.c
++++ b/net/ipv4/ip_tunnel.c
+@@ -520,8 +520,7 @@ static int tnl_update_pmtu(struct net_device *dev, struct sk_buff *skb,
+ 	else
+ 		mtu = skb_dst(skb) ? dst_mtu(skb_dst(skb)) : dev->mtu;
+ 
+-	if (skb_dst(skb))
+-		skb_dst(skb)->ops->update_pmtu(skb_dst(skb), NULL, skb, mtu);
++	skb_dst_update_pmtu(skb, mtu);
+ 
+ 	if (skb->protocol == htons(ETH_P_IP)) {
+ 		if (!skb_is_gso(skb) &&
+diff --git a/net/ipv4/ip_vti.c b/net/ipv4/ip_vti.c
+index 89453cf62158..c9cd891f69c2 100644
+--- a/net/ipv4/ip_vti.c
++++ b/net/ipv4/ip_vti.c
+@@ -209,7 +209,7 @@ static netdev_tx_t vti_xmit(struct sk_buff *skb, struct net_device *dev,
+ 
+ 	mtu = dst_mtu(dst);
+ 	if (skb->len > mtu) {
+-		skb_dst(skb)->ops->update_pmtu(skb_dst(skb), NULL, skb, mtu);
++		skb_dst_update_pmtu(skb, mtu);
+ 		if (skb->protocol == htons(ETH_P_IP)) {
+ 			icmp_send(skb, ICMP_DEST_UNREACH, ICMP_FRAG_NEEDED,
+ 				  htonl(mtu));
+diff --git a/net/ipv6/ip6_tunnel.c b/net/ipv6/ip6_tunnel.c
+index 1161fd5630c1..b825cb5a5123 100644
+--- a/net/ipv6/ip6_tunnel.c
++++ b/net/ipv6/ip6_tunnel.c
+@@ -649,7 +649,7 @@ ip4ip6_err(struct sk_buff *skb, struct inet6_skb_parm *opt,
+ 		if (rel_info > dst_mtu(skb_dst(skb2)))
+ 			goto out;
+ 
+-		skb_dst(skb2)->ops->update_pmtu(skb_dst(skb2), NULL, skb2, rel_info);
++		skb_dst_update_pmtu(skb2, rel_info);
+ 	}
+ 	if (rel_type == ICMP_REDIRECT)
+ 		skb_dst(skb2)->ops->redirect(skb_dst(skb2), NULL, skb2);
+@@ -1138,8 +1138,7 @@ int ip6_tnl_xmit(struct sk_buff *skb, struct net_device *dev, __u8 dsfield,
+ 		mtu = 576;
+ 	}
+ 
+-	if (skb_dst(skb) && !t->parms.collect_md)
+-		skb_dst(skb)->ops->update_pmtu(skb_dst(skb), NULL, skb, mtu);
++	skb_dst_update_pmtu(skb, mtu);
+ 	if (skb->len - t->tun_hlen - eth_hlen > mtu && !skb_is_gso(skb)) {
+ 		*pmtu = mtu;
+ 		err = -EMSGSIZE;
+diff --git a/net/ipv6/ip6_vti.c b/net/ipv6/ip6_vti.c
+index 413f01be0c9b..8284c6697936 100644
+--- a/net/ipv6/ip6_vti.c
++++ b/net/ipv6/ip6_vti.c
+@@ -483,7 +483,7 @@ vti6_xmit(struct sk_buff *skb, struct net_device *dev, struct flowi *fl)
+ 
+ 	mtu = dst_mtu(dst);
+ 	if (!skb->ignore_df && skb->len > mtu) {
+-		skb_dst(skb)->ops->update_pmtu(dst, NULL, skb, mtu);
++		skb_dst_update_pmtu(skb, mtu);
+ 
+ 		if (skb->protocol == htons(ETH_P_IPV6)) {
+ 			if (mtu < IPV6_MIN_MTU)
+diff --git a/net/ipv6/sit.c b/net/ipv6/sit.c
+index cac815cc8600..360317b968b7 100644
+--- a/net/ipv6/sit.c
++++ b/net/ipv6/sit.c
+@@ -923,8 +923,8 @@ static netdev_tx_t ipip6_tunnel_xmit(struct sk_buff *skb,
+ 			df = 0;
+ 		}
+ 
+-		if (tunnel->parms.iph.daddr && skb_dst(skb))
+-			skb_dst(skb)->ops->update_pmtu(skb_dst(skb), NULL, skb, mtu);
++		if (tunnel->parms.iph.daddr)
++			skb_dst_update_pmtu(skb, mtu);
+ 
+ 		if (skb->len > mtu && !skb_is_gso(skb)) {
+ 			icmpv6_send(skb, ICMPV6_PKT_TOOBIG, 0, mtu);
+-- 
+2.13.6
+


### PR DESCRIPTION
Not fixing on 1729 since it won't promote to beta and 4.15 isn't affected.