### PR TITLE
Automatically rebuild Rust projects when Rust is updated

### DIFF
--- a/dev-libs/rustlib/rustlib-1.25.0.ebuild
+++ b/dev-libs/rustlib/rustlib-1.25.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2017 CoreOS, Inc.
+# Copyright 2017-2018 CoreOS, Inc.
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -14,7 +14,7 @@ S="${WORKDIR}/rustc-${PV}-src"
 
 RDEPEND="!dev-lang/rust"
 
-SLOT="0"
+SLOT="0/${PVR}"
 KEYWORDS="amd64 arm64"
 
 src_configure() {

--- a/eclass/coreos-cargo.eclass
+++ b/eclass/coreos-cargo.eclass
@@ -1,4 +1,4 @@
-# Copyright 2017 CoreOS, Inc.
+# Copyright 2017-2018 CoreOS, Inc.
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: coreos-cargo.eclass
@@ -18,7 +18,7 @@ inherit toolchain-funcs
 EXPORT_FUNCTIONS src_unpack
 
 [[ ${CATEGORY}/${PN} != dev-libs/rustlib ]] && DEPEND="|| (
-	dev-libs/rustlib
+	dev-libs/rustlib:=
 	dev-util/cargo
 )"
 


### PR DESCRIPTION
In particular, this makes CI builds useful while reusing binary packages.