### PR TITLE
sys-kernel/coreos-sources: add dep on bison, flex

### DIFF
--- a/sys-kernel/coreos-sources/coreos-sources-4.16.7.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-4.16.7.ebuild
@@ -25,6 +25,10 @@ fi
 
 KEYWORDS="amd64 arm64"
 IUSE=""
+RDEPEND+="
+	sys-devel/bison
+	sys-devel/flex
+"
 
 # XXX: Note we must prefix the patch filenames with "z" to ensure they are
 # applied _after_ a potential patch-${KV}.patch file, present when building a


### PR DESCRIPTION
The 4.16.x line and up now need flex and bison to build the kernel. Add
it here so people using our dev container will pick it up automatically.