### PR TITLE
profiles/arm64: remove wget accept

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -39,7 +39,6 @@
 =net-misc/bridge-utils-1.5 ~arm64
 =net-misc/iperf-3.1.3 **
 =net-misc/socat-1.7.3.2 ~arm64
-=net-misc/wget-1.19.1-r2 ~arm64
 =net-nds/openldap-2.4.44 ~arm64
 =perl-core/File-Path-2.130.0 ~arm64
 =sys-apps/gptfdisk-1.0.1 ~arm64


### PR DESCRIPTION
Upstream has marked 1.19.5 as stable on arm64

Part of https://github.com/coreos/portage-stable/pull/662