### PR TITLE
profiles: drop obsolete git accepts

### DIFF
--- a/profiles/coreos/arm64/package.accept_keywords
+++ b/profiles/coreos/arm64/package.accept_keywords
@@ -25,7 +25,6 @@
 =dev-util/meson-0.43.0 ~arm64
 =dev-util/ninja-1.8.2 ~arm64
 =dev-util/re2c-0.16 ~arm64
-=dev-vcs/git-2.13.0 ~arm64
 =net-analyzer/nmap-7.40 ~arm64
 =net-analyzer/tcpdump-4.9.2 ~arm64
 =net-dialup/minicom-2.7.1 ~arm64

--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -54,9 +54,6 @@ dev-util/checkbashisms
 # Pick up fixes for bugs introduced in 4.0
 =sys-fs/dosfstools-4.1 **
 
-# CVE-2017-1000117
-=dev-vcs/git-2.14.1
-
 # iproute2 4.13 includes a patch to avoid leaking netns mounts in rkt 
 # https://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git/commit/?id=d6a4076b6ba6547d7e52c377a7c58c56eb5ea16e
 =sys-apps/iproute2-4.13.0 ~amd64 ~arm64


### PR DESCRIPTION
Part of https://github.com/coreos/portage-stable/pull/665.