### PR TITLE
profiles: mask git hook implemented in perl

### DIFF
--- a/profiles/coreos/targets/generic/make.defaults
+++ b/profiles/coreos/targets/generic/make.defaults
@@ -48,6 +48,7 @@ INSTALL_MASK="${INSTALL_MASK}
 
   /usr/lib/modules/*-coreos/source/scripts/*.pl
 
+  /usr/share/git-core/templates/hooks/fsmonitor-watchman.sample
   /usr/share/rsync/*
 
   /usr/bin/glib-mkenums


### PR DESCRIPTION
Fixes `build_image` warning:

    /usr/share/git-core/templates/hooks/fsmonitor-watchman.sample: /usr/bin/perl does not exist
    WARNING build_image: test_image_content: Failed #! check