### PR TITLE
sys-apps/portage: Support new file command output

### DIFF
--- a/sys-apps/portage/files/portage-2.3.8-file-update.patch
+++ b/sys-apps/portage/files/portage-2.3.8-file-update.patch
@@ -1,0 +1,23 @@
+Add support for new file command output.
+
+--- bin/ebuild-helpers/prepstrip
++++ bin/ebuild-helpers/prepstrip
+@@ -346,7 +346,7 @@
+ 				${STRIP} -g "${x}"
+ 			fi
+ 		fi
+-	elif [[ ${f} == *"SB executable"* || ${f} == *"SB shared object"* ]] ; then
++	elif [[ ${f} == *"SB executable"* || ${f} == *"SB pie executable"* || ${f} == *"SB shared object"* ]] ; then
+ 		process_elf "${x}" "${inode_link}" ${PORTAGE_STRIP_FLAGS}
+ 	elif [[ ${f} == *"SB relocatable"* ]] ; then
+ 		process_elf "${x}" "${inode_link}" ${SAFE_STRIP_FLAGS}
+--- bin/install-qa-check.d/10ignored-flags
++++ bin/install-qa-check.d/10ignored-flags
+@@ -33,6 +33,7 @@
+ 			f=$(file "${x}") || continue
+ 			[[ -z ${f} ]] && continue
+ 			if [[ ${f} == *"SB executable"* ||
++				${f} == *"SB pie executable"* ||
+ 				${f} == *"SB shared object"* ]] ; then
+ 				echo "${x}" >> "${T}"/scanelf-ignored-CFLAGS.log
+ 			fi

--- a/sys-apps/portage/portage-2.3.8-r1.ebuild
+++ b/sys-apps/portage/portage-2.3.8-r1.ebuild
@@ -87,6 +87,8 @@ PATCHES=(
 	"${FILESDIR}/${PN}-2.2.18-0002-environment-Filter-EROOT-for-all-EAPIs.patch"
 	# upstream bug:
 	"${FILESDIR}/${PN}-2.2.18-0003-depgraph-ensure-slot-rebuilds-happen-in-the-correct-.patch"
+	# support new file command output (this can be dropped when upgrading)
+	"${FILESDIR}/${P}-file-update.patch"
 )
 
 pkg_setup() {


### PR DESCRIPTION
Testing this as a temporary alternative to #3311 until toolchains bootstrapping issues are solved.