### PR TITLE
nvme timeout issue patch. for kernel below 4.15

### DIFF
--- a/coreos-base/oem-ec2-compat/files/grub-ec2.cfg
+++ b/coreos-base/oem-ec2-compat/files/grub-ec2.cfg
@@ -7,7 +7,7 @@ set oem_id="ec2"
 set linux_append="modprobe.blacklist=xen_fbfront net.ifnames=0"
 
 if [ "$grub_platform" = pc ]; then
-	set linux_console="console=ttyS0,115200n8"
+	set linux_console="console=ttyS0,115200n8 nvme_core.io_timeout=255 nvme_core.max_retries=10"
 	serial com0 --speed=115200 --word=8 --parity=no
 	terminal_input serial_com0
 	terminal_output serial_com0

--- a/coreos-base/oem-ec2-compat/files/grub-ec2.cfg
+++ b/coreos-base/oem-ec2-compat/files/grub-ec2.cfg
@@ -7,7 +7,7 @@ set oem_id="ec2"
 set linux_append="modprobe.blacklist=xen_fbfront net.ifnames=0"
 
 if [ "$grub_platform" = pc ]; then
-	set linux_console="console=ttyS0,115200n8 nvme_core.io_timeout=255 nvme_core.max_retries=10"
+	set linux_append="console=ttyS0,115200n8 nvme_core.io_timeout=255 nvme_core.max_retries=10"
 	serial com0 --speed=115200 --word=8 --parity=no
 	terminal_input serial_com0
 	terminal_output serial_com0


### PR DESCRIPTION
updating the grub config to use the nvme defaults required by aws. Should solve the failure to pass status checks. (eventually)
This only works on kernel version above 4.15. (core timeout max is 255 for below 4.15)

coreos/bugs#2464
coreos/bugs#2484
coreos/bugs#2371
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes
05c1f12