### PR TITLE
profiles: Disable arm64 support in QEMU and Rust

### DIFF
--- a/profiles/coreos/targets/sdk/make.defaults
+++ b/profiles/coreos/targets/sdk/make.defaults
@@ -8,13 +8,10 @@ CROS_SDK_HOST="cros-sdk-host"
 GRUB_PLATFORMS="efi-64 pc xen"
 
 # Enable CPU architectures needed by Rust builds
-LLVM_TARGETS="X86 AArch64"
+LLVM_TARGETS="X86"
 
 # Both x86_64 and i386 targets are required for grub testing
-QEMU_SOFTMMU_TARGETS="x86_64 i386 aarch64"
-
-# For cross build support.
-QEMU_USER_TARGETS="aarch64"
+QEMU_SOFTMMU_TARGETS="x86_64 i386"
 
 # Disable ccache in the SDK so it stops randomly breaking catalyst.
 FEATURES="-ccache"


### PR DESCRIPTION
Since the kernel is no longer buildable for arm64, disable the QEMU targets that were used by dracut to create the arm64 initramfs.  Also disable LLVM's arm64 support to speed up SDK Rust builds.

(There is much more to be done for real arm64 removal; this is just to make our SDK builds faster until then.)