### PR TITLE
coreos/base/oem-ec2-compat: set linux_console to serial on openstack

### DIFF
--- a/coreos-base/oem-ec2-compat/files/grub-openstack.cfg
+++ b/coreos-base/oem-ec2-compat/files/grub-openstack.cfg
@@ -1,3 +1,10 @@
 # CoreOS GRUB settings for EC2
 
 set oem_id="openstack"
+
+if [ "$grub_platform" = pc ]; then
+	set linux_console="console=ttyS0,115200n8"
+	serial com0 --speed=115200 --word=8 --parity=no
+	terminal_input serial_com0
+	terminal_output serial_com0
+fi


### PR DESCRIPTION
In current builds of the OpenStack format we are not setting the
linux_console to the serial console. As a byproduct of coreos/bugs#2136
this means that currently Ignition logs are not retrievable from the
OpenStack console history API.