### PR TITLE
profiles: accept Git 2.16.5 but nothing newer for stable

### DIFF
--- a/profiles/coreos/base/package.accept_keywords
+++ b/profiles/coreos/base/package.accept_keywords
@@ -64,3 +64,5 @@ dev-util/checkbashisms
 =app-crypt/gnupg-2.2.7 ~amd64 ~arm64
 =sys-apps/gptfdisk-1.0.3 ~amd64 ~arm64
 =sys-apps/util-linux-2.32 ~amd64 ~arm64
+
+=dev-vcs/git-2.16.5 ~amd64

--- a/profiles/coreos/base/package.mask
+++ b/profiles/coreos/base/package.mask
@@ -14,3 +14,5 @@
 # mask an accidental rkt major version bump to ensure it's not chosen over more
 # recent releases
 =app-emulation/rkt-13.0
+
+>=dev-vcs/git-2.17


### PR DESCRIPTION
Fixes CVE-2018-17456.

Part of https://github.com/coreos/portage-stable/pull/692.