### PR TITLE
profiles: Exclude masking kernel headers

### DIFF
--- a/profiles/coreos/targets/generic/prod/make.defaults
+++ b/profiles/coreos/targets/generic/prod/make.defaults
@@ -8,6 +8,7 @@ INSTALL_MASK="${INSTALL_MASK}
   /lib*/pkgconfig
   /usr/include
   /usr/lib*/*/include
+  -/usr/lib*/modules/*/include
   /usr/lib*/cmake
   /usr/lib*/debug
   /usr/lib*/pkgconfig


### PR DESCRIPTION
Since the last portage update, the pattern behavior seems to have changed so that globbing matches subdirectories at any depth (which contradicts its documentation).  Work around this by explicitly excluding the kernel modules from the pattern.

This was breaking building some kernel modules in the developer container when the production image's /lib/modules was bind mounted into the container.