### PR TITLE
sys-kernel/coreos-*: work around missing nf_conntrack_ipv4 for kube-proxy

### DIFF
--- a/sys-kernel/coreos-kernel/coreos-kernel-4.19.0-r1.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-4.19.0-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION=""
+COREOS_SOURCE_REVISION="-r1"
 inherit coreos-kernel
 
 DESCRIPTION="CoreOS Linux kernel"

--- a/sys-kernel/coreos-modules/coreos-modules-4.19.0-r1.ebuild
+++ b/sys-kernel/coreos-modules/coreos-modules-4.19.0-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION=""
+COREOS_SOURCE_REVISION="-r1"
 inherit coreos-kernel savedconfig
 
 DESCRIPTION="CoreOS Linux kernel modules"

--- a/sys-kernel/coreos-sources/coreos-sources-4.19.0-r1.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-4.19.0-r1.ebuild
@@ -37,4 +37,5 @@ RDEPEND+="
 UNIPATCH_LIST="
 	${PATCH_DIR}/z0001-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch \
 	${PATCH_DIR}/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch \
+	${PATCH_DIR}/z0003-net-netfilter-add-nf_conntrack_ipv4-compat-module-fo.patch \
 "

--- a/sys-kernel/coreos-sources/files/4.19/z0001-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch
+++ b/sys-kernel/coreos-sources/files/4.19/z0001-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch
@@ -1,7 +1,7 @@
 From 032844ef57f314206644fc41cc215216c29ec336 Mon Sep 17 00:00:00 2001
 From: Vito Caputo <vito.caputo@coreos.com>
 Date: Wed, 25 Nov 2015 02:59:45 -0800
-Subject: [PATCH 1/2] kbuild: derive relative path for KBUILD_SRC from CURDIR
+Subject: [PATCH 1/3] kbuild: derive relative path for KBUILD_SRC from CURDIR
 
 This enables relocating source and build trees to different roots,
 provided they stay reachable relative to one another.  Useful for

--- a/sys-kernel/coreos-sources/files/4.19/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch
+++ b/sys-kernel/coreos-sources/files/4.19/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch
@@ -1,7 +1,7 @@
 From 175b5d6d56990d94e5f2e848923b1e358be3cd39 Mon Sep 17 00:00:00 2001
 From: David Michael <david.michael@coreos.com>
 Date: Thu, 8 Feb 2018 21:23:12 -0500
-Subject: [PATCH 2/2] tools/objtool/Makefile: Don't fail on fallthrough with
+Subject: [PATCH 2/3] tools/objtool/Makefile: Don't fail on fallthrough with
  new GCCs
 
 ---

--- a/sys-kernel/coreos-sources/files/4.19/z0003-net-netfilter-add-nf_conntrack_ipv4-compat-module-fo.patch
+++ b/sys-kernel/coreos-sources/files/4.19/z0003-net-netfilter-add-nf_conntrack_ipv4-compat-module-fo.patch
@@ -1,0 +1,87 @@
+From 8fdc104582cf65fc4665a799a7de03f157907066 Mon Sep 17 00:00:00 2001
+From: Benjamin Gilbert <bgilbert@redhat.com>
+Date: Fri, 26 Oct 2018 17:00:56 -0700
+Subject: [PATCH 3/3] net/netfilter: add nf_conntrack_ipv4 compat module for
+ kube-proxy
+
+kube-proxy won't enable ipvs unless it can modprobe nf_conntrack_ipv4 and
+find it in the list of loaded modules afterward.  Thus an alias isn't
+enough to maintain compatibility; we need an actual module.
+---
+ net/netfilter/Kconfig             |  8 ++++++++
+ net/netfilter/Makefile            |  1 +
+ net/netfilter/nf_conntrack_ipv4.c | 31 +++++++++++++++++++++++++++++++
+ 3 files changed, 40 insertions(+)
+ create mode 100644 net/netfilter/nf_conntrack_ipv4.c
+
+diff --git a/net/netfilter/Kconfig b/net/netfilter/Kconfig
+index f61c306de1d0..63f2924b5709 100644
+--- a/net/netfilter/Kconfig
++++ b/net/netfilter/Kconfig
+@@ -70,6 +70,14 @@ config NF_CONNTRACK
+ 
+ 	  To compile it as a module, choose M here.  If unsure, say N.
+ 
++config NF_CONNTRACK_IPV4_COMPAT
++	tristate "Netfilter connection tracking IPv4 compatibility module"
++	depends on NF_CONNTRACK
++	default NF_CONNTRACK
++	help
++	  Compatibility nf_conntrack_ipv4 module that loads nf_conntrack.ko,
++	  since kube-proxy cares about the names of loaded kernel modules.
++
+ config NF_LOG_COMMON
+ 	tristate
+ 
+diff --git a/net/netfilter/Makefile b/net/netfilter/Makefile
+index 16895e045b66..24d8da425ed8 100644
+--- a/net/netfilter/Makefile
++++ b/net/netfilter/Makefile
+@@ -24,6 +24,7 @@ obj-$(CONFIG_NETFILTER_NETLINK_OSF) += nfnetlink_osf.o
+ 
+ # connection tracking
+ obj-$(CONFIG_NF_CONNTRACK) += nf_conntrack.o
++obj-$(CONFIG_NF_CONNTRACK_IPV4_COMPAT) += nf_conntrack_ipv4.o
+ 
+ obj-$(CONFIG_NF_CT_PROTO_GRE) += nf_conntrack_proto_gre.o
+ 
+diff --git a/net/netfilter/nf_conntrack_ipv4.c b/net/netfilter/nf_conntrack_ipv4.c
+new file mode 100644
+index 000000000000..8308772022c6
+--- /dev/null
++++ b/net/netfilter/nf_conntrack_ipv4.c
+@@ -0,0 +1,31 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Compatibility nf_conntrack_ipv4 module that depends on nf_conntrack
++ * to keep kube-proxy happy.
++ *
++ * Copyright (c) 2018 Red Hat, Inc.
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License as published by the Free
++ * Software Foundation; either version 2 of the License, or (at your option)
++ * any later version.
++ */
++
++#include <linux/module.h>
++#include <linux/printk.h>
++#include <net/netfilter/nf_conntrack.h>
++
++unsigned int *pointer_to_nf_conntrack_data = &nf_conntrack_max;
++
++static int __init nf_conntrack_ipv4_init(void) {
++	pr_notice("nf_conntrack_ipv4: loaded compatibility alias for nf_conntrack\n");
++	return 0;
++}
++
++static void __exit nf_conntrack_ipv4_exit(void) {}
++
++module_init(nf_conntrack_ipv4_init);
++module_exit(nf_conntrack_ipv4_exit);
++
++MODULE_DESCRIPTION("kube-proxy compatibility wrapper for nf_conntrack.ko");
++MODULE_LICENSE("GPL");
+-- 
+2.17.2
+


### PR DESCRIPTION
Fixes https://github.com/coreos/bugs/issues/2518.

https://github.com/coreos/linux/pull/272