### PR TITLE
profiles: Skip SSSD in the GCE OEM ACI

### DIFF
--- a/profiles/coreos/targets/generic/oem-aci/package.provided
+++ b/profiles/coreos/targets/generic/oem-aci/package.provided
@@ -1,0 +1,2 @@
+# Do not install SSSD in the container.
+sys-auth/sssd-1.13.1


### PR DESCRIPTION
Fixes #3527 for GCE