### PR TITLE
profiles: Build rustfmt in the SDK

### DIFF
--- a/profiles/coreos/targets/sdk/package.use
+++ b/profiles/coreos/targets/sdk/package.use
@@ -5,6 +5,8 @@ dev-vcs/git pcre
 dev-util/catalyst ccache
 dev-lang/python sqlite
 
+dev-lang/rust rustfmt
+
 # Allow smartcard support in the SDK for image signing
 app-crypt/gnupg smartcard usb
 


### PR DESCRIPTION
No scripts depend on this (yet); it's just for manual checking.