### PR TITLE
profiles: Fix the XFS Python unit path

### DIFF
--- a/profiles/coreos/targets/generic/prod/make.defaults
+++ b/profiles/coreos/targets/generic/prod/make.defaults
@@ -33,7 +33,7 @@ INSTALL_MASK="${INSTALL_MASK}
 
 # Remove files which depend on interpreters not present in boards.
 INSTALL_MASK="${INSTALL_MASK}
-  /lib/systemd/system/xfs_scrub_all*
+  /usr/lib*/systemd/system/xfs_scrub_all*
   /usr/share/git/contrib/*
   /usr/bin/diff-highlight
   /usr/bin/autoscan-2.13


### PR DESCRIPTION
This was using the unit path in the SDK, which misses the files in production images.

Fixes #3542