### PR TITLE
profiles: Revert the last util-linux upgrade

### DIFF
--- a/profiles/coreos/base/package.mask
+++ b/profiles/coreos/base/package.mask
@@ -14,3 +14,6 @@
 # mask an accidental rkt major version bump to ensure it's not chosen over more
 # recent releases
 =app-emulation/rkt-13.0
+
+# This causes build failures from loop device partitions never being cleaned.
+>=sys-apps/util-linux-2.33


### PR DESCRIPTION
Repeated OS builds started failing from partitioned loop devices never being removed after the 2.33 update.