### PR TITLE
Revert "profiles: Revert the last util-linux upgrade"

### DIFF
--- a/profiles/coreos/base/package.mask
+++ b/profiles/coreos/base/package.mask
@@ -14,6 +14,3 @@
 # mask an accidental rkt major version bump to ensure it's not chosen over more
 # recent releases
 =app-emulation/rkt-13.0
-
-# This causes build failures from loop device partitions never being cleaned.
->=sys-apps/util-linux-2.33


### PR DESCRIPTION
This might not have had the intended effect, so undo it until it is investigated further to avoid version changing noise in releases.

Reverts #3556