### PR TITLE
sys-kernel/coreos-sources: fix POSIX timer rearming for stable

### DIFF
--- a/sys-kernel/coreos-kernel/coreos-kernel-4.14.96-r1.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-4.14.96-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION=""
+COREOS_SOURCE_REVISION="-r1"
 inherit coreos-kernel
 
 DESCRIPTION="CoreOS Linux kernel"

--- a/sys-kernel/coreos-modules/coreos-modules-4.14.96-r1.ebuild
+++ b/sys-kernel/coreos-modules/coreos-modules-4.14.96-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION=""
+COREOS_SOURCE_REVISION="-r1"
 inherit coreos-kernel savedconfig
 
 DESCRIPTION="CoreOS Linux kernel modules"

--- a/sys-kernel/coreos-sources/coreos-sources-4.14.96-r1.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-4.14.96-r1.ebuild
@@ -33,4 +33,5 @@ IUSE=""
 UNIPATCH_LIST="
 	${PATCH_DIR}/z0001-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch \
 	${PATCH_DIR}/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch \
+	${PATCH_DIR}/z0003-posix-cpu-timers-Unbreak-timer-rearming.patch \
 "

--- a/sys-kernel/coreos-sources/files/4.14/z0001-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch
+++ b/sys-kernel/coreos-sources/files/4.14/z0001-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch
@@ -1,7 +1,7 @@
 From 30c5be3392e203001f0410e70c88fab3ac925a14 Mon Sep 17 00:00:00 2001
 From: Vito Caputo <vito.caputo@coreos.com>
 Date: Wed, 25 Nov 2015 02:59:45 -0800
-Subject: [PATCH 1/2] kbuild: derive relative path for KBUILD_SRC from CURDIR
+Subject: [PATCH 1/3] kbuild: derive relative path for KBUILD_SRC from CURDIR
 
 This enables relocating source and build trees to different roots,
 provided they stay reachable relative to one another.  Useful for

--- a/sys-kernel/coreos-sources/files/4.14/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch
+++ b/sys-kernel/coreos-sources/files/4.14/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch
@@ -1,7 +1,7 @@
 From c0d474bb2e730f7f96ec9503e696e4944f903725 Mon Sep 17 00:00:00 2001
 From: David Michael <david.michael@coreos.com>
 Date: Thu, 8 Feb 2018 21:23:12 -0500
-Subject: [PATCH 2/2] tools/objtool/Makefile: Don't fail on fallthrough with
+Subject: [PATCH 2/3] tools/objtool/Makefile: Don't fail on fallthrough with
  new GCCs
 
 ---

--- a/sys-kernel/coreos-sources/files/4.14/z0003-posix-cpu-timers-Unbreak-timer-rearming.patch
+++ b/sys-kernel/coreos-sources/files/4.14/z0003-posix-cpu-timers-Unbreak-timer-rearming.patch
@@ -1,0 +1,54 @@
+From 4c38d059f0b80289b9d1bb95828e7f49bfafce1e Mon Sep 17 00:00:00 2001
+From: Thomas Gleixner <tglx@linutronix.de>
+Date: Fri, 11 Jan 2019 14:33:16 +0100
+Subject: [PATCH 3/3] posix-cpu-timers: Unbreak timer rearming
+
+commit 93ad0fc088c5b4631f796c995bdd27a082ef33a6 upstream.
+
+The recent commit which prevented a division by 0 issue in the alarm timer
+code broke posix CPU timers as an unwanted side effect.
+
+The reason is that the common rearm code checks for timer->it_interval
+being 0 now. What went unnoticed is that the posix cpu timer setup does not
+initialize timer->it_interval as it stores the interval in CPU timer
+specific storage. The reason for the separate storage is historical as the
+posix CPU timers always had a 64bit nanoseconds representation internally
+while timer->it_interval is type ktime_t which used to be a modified
+timespec representation on 32bit machines.
+
+Instead of reverting the offending commit and fixing the alarmtimer issue
+in the alarmtimer code, store the interval in timer->it_interval at CPU
+timer setup time so the common code check works. This also repairs the
+existing inconistency of the posix CPU timer code which kept a single shot
+timer armed despite of the interval being 0.
+
+The separate storage can be removed in mainline, but that needs to be a
+separate commit as the current one has to be backported to stable kernels.
+
+Fixes: 0e334db6bb4b ("posix-timers: Fix division by zero bug")
+Reported-by: H.J. Lu <hjl.tools@gmail.com>
+Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
+Cc: John Stultz <john.stultz@linaro.org>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Cc: stable@vger.kernel.org
+Link: https://lkml.kernel.org/r/20190111133500.840117406@linutronix.de
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ kernel/time/posix-cpu-timers.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/time/posix-cpu-timers.c b/kernel/time/posix-cpu-timers.c
+index 2da660d53a4b..6e8c230ca877 100644
+--- a/kernel/time/posix-cpu-timers.c
++++ b/kernel/time/posix-cpu-timers.c
+@@ -685,6 +685,7 @@ static int posix_cpu_timer_set(struct k_itimer *timer, int timer_flags,
+ 	 * set up the signal and overrun bookkeeping.
+ 	 */
+ 	timer->it.cpu.incr = timespec64_to_ns(&new->it_interval);
++	timer->it_interval = ns_to_ktime(timer->it.cpu.incr);
+ 
+ 	/*
+ 	 * This acts as a modification timestamp for the timer,
+-- 
+2.20.1
+


### PR DESCRIPTION
Alpha and beta already have kernels with the fix.

Addresses https://github.com/coreos/bugs/issues/2549.

https://github.com/coreos/linux/pull/302