### PR TITLE
app-torcx/docker: Pin the latest image to its tini version

### DIFF
--- a/app-torcx/docker/docker-18.06.ebuild
+++ b/app-torcx/docker/docker-18.06.ebuild
@@ -16,7 +16,7 @@ RDEPEND="
 	~app-emulation/docker-proxy-0.8.0_p20180709
 	~app-emulation/docker-runc-1.0.0_rc5_p22
 	=dev-libs/libltdl-2.4.6
-	=sys-process/tini-0.13.2
+	=sys-process/tini-0.18.0
 "
 
 src_install() {

--- a/metadata/md5-cache/app-torcx/docker-18.06
+++ b/metadata/md5-cache/app-torcx/docker-18.06
@@ -3,6 +3,6 @@ DESCRIPTION=Packages to be installed in a torcx image for Docker
 EAPI=2
 KEYWORDS=amd64 arm64
 LICENSE=GPL-2
-RDEPEND=~app-emulation/docker-18.06.3 ~app-emulation/containerd-1.1.2 ~app-emulation/docker-proxy-0.8.0_p20180709 ~app-emulation/docker-runc-1.0.0_rc5_p22 =dev-libs/libltdl-2.4.6 =sys-process/tini-0.13.2
+RDEPEND=~app-emulation/docker-18.06.3 ~app-emulation/containerd-1.1.2 ~app-emulation/docker-proxy-0.8.0_p20180709 ~app-emulation/docker-runc-1.0.0_rc5_p22 =dev-libs/libltdl-2.4.6 =sys-process/tini-0.18.0
 SLOT=0
-_md5_=3db2176202d29e476a0eac4c9c2b0d55
+_md5_=984fbdaedb6fad322e2dcc925c5b32ce


### PR DESCRIPTION
This only updates the 18.06 image to match what upstream Docker and Fedora are using.  The 17.03 image always used a newer tini version than upstream (a commit just before 0.13.1), and the 1.12 image doesn't use tini at all.

Requires coreos/portage-stable#724