### PR TITLE
profiles: Use Python 3 for glib-utils

### DIFF
--- a/profiles/coreos/base/package.use
+++ b/profiles/coreos/base/package.use
@@ -25,6 +25,9 @@ dev-python/pyblake2 -python_targets_python3_6
 dev-python/uritemplate -python_targets_python3_6
 sys-apps/portage -python_targets_python3_6
 
+# python3 only
+dev-util/glib-utils python_single_target_python3_6
+
 sys-apps/gptfdisk -icu
 
 # for profile migration

--- a/profiles/coreos/targets/generic/package.provided
+++ b/profiles/coreos/targets/generic/package.provided
@@ -22,3 +22,6 @@ app-arch/xz-utils-0
 
 # doesn't cross-compile, but required for glog, gflags, etc.
 dev-util/cmake-3.9.6
+
+# pulled in by dev-libs/glib
+dev-util/glib-utils-9999


### PR DESCRIPTION
Part of coreos/portage-stable#726