### PR TITLE
sys-kernel/coreos-sources: fix overlayfs Docker breakage in 4.19.56+

### DIFF
--- a/sys-kernel/coreos-kernel/coreos-kernel-4.19.57-r1.ebuild
+++ b/sys-kernel/coreos-kernel/coreos-kernel-4.19.57-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION=""
+COREOS_SOURCE_REVISION="-r1"
 inherit coreos-kernel
 
 DESCRIPTION="CoreOS Linux kernel"

--- a/sys-kernel/coreos-modules/coreos-modules-4.19.57-r1.ebuild
+++ b/sys-kernel/coreos-modules/coreos-modules-4.19.57-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
-COREOS_SOURCE_REVISION=""
+COREOS_SOURCE_REVISION="-r1"
 inherit coreos-kernel savedconfig
 
 DESCRIPTION="CoreOS Linux kernel modules"

--- a/sys-kernel/coreos-sources/coreos-sources-4.19.57-r1.ebuild
+++ b/sys-kernel/coreos-sources/coreos-sources-4.19.57-r1.ebuild
@@ -34,4 +34,5 @@ UNIPATCH_LIST="
 	${PATCH_DIR}/z0001-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch \
 	${PATCH_DIR}/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch \
 	${PATCH_DIR}/z0003-net-netfilter-add-nf_conntrack_ipv4-compat-module-fo.patch \
+	${PATCH_DIR}/z0004-ovl-drop-test-for-upperdir-used-as-lowerdir.patch \
 "

--- a/sys-kernel/coreos-sources/files/4.19/z0001-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch
+++ b/sys-kernel/coreos-sources/files/4.19/z0001-kbuild-derive-relative-path-for-KBUILD_SRC-from-CURD.patch
@@ -1,7 +1,7 @@
 From 557eff8a6ee3d61213dc488de8faad93364319da Mon Sep 17 00:00:00 2001
 From: Vito Caputo <vito.caputo@coreos.com>
 Date: Wed, 25 Nov 2015 02:59:45 -0800
-Subject: [PATCH 1/3] kbuild: derive relative path for KBUILD_SRC from CURDIR
+Subject: [PATCH 1/4] kbuild: derive relative path for KBUILD_SRC from CURDIR
 
 This enables relocating source and build trees to different roots,
 provided they stay reachable relative to one another.  Useful for

--- a/sys-kernel/coreos-sources/files/4.19/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch
+++ b/sys-kernel/coreos-sources/files/4.19/z0002-tools-objtool-Makefile-Don-t-fail-on-fallthrough-wit.patch
@@ -1,7 +1,7 @@
 From e183dbfdf2e89ea52df69973d66fb55b6d46ecee Mon Sep 17 00:00:00 2001
 From: David Michael <david.michael@coreos.com>
 Date: Thu, 8 Feb 2018 21:23:12 -0500
-Subject: [PATCH 2/3] tools/objtool/Makefile: Don't fail on fallthrough with
+Subject: [PATCH 2/4] tools/objtool/Makefile: Don't fail on fallthrough with
  new GCCs
 
 ---

--- a/sys-kernel/coreos-sources/files/4.19/z0003-net-netfilter-add-nf_conntrack_ipv4-compat-module-fo.patch
+++ b/sys-kernel/coreos-sources/files/4.19/z0003-net-netfilter-add-nf_conntrack_ipv4-compat-module-fo.patch
@@ -1,7 +1,7 @@
 From 83911c6129649f4f72fdc9ca28cf07d0f8bab253 Mon Sep 17 00:00:00 2001
 From: Benjamin Gilbert <bgilbert@redhat.com>
 Date: Fri, 26 Oct 2018 17:00:56 -0700
-Subject: [PATCH 3/3] net/netfilter: add nf_conntrack_ipv4 compat module for
+Subject: [PATCH 3/4] net/netfilter: add nf_conntrack_ipv4 compat module for
  kube-proxy
 
 kube-proxy won't enable ipvs unless it can modprobe nf_conntrack_ipv4 and

--- a/sys-kernel/coreos-sources/files/4.19/z0004-ovl-drop-test-for-upperdir-used-as-lowerdir.patch
+++ b/sys-kernel/coreos-sources/files/4.19/z0004-ovl-drop-test-for-upperdir-used-as-lowerdir.patch
@@ -1,0 +1,35 @@
+From 86f76273f6f49440b8f622fec3d31dc1e0a4a28d Mon Sep 17 00:00:00 2001
+From: Benjamin Gilbert <bgilbert@redhat.com>
+Date: Tue, 9 Jul 2019 19:53:49 -0400
+Subject: [PATCH 4/4] ovl: drop test for upperdir used as lowerdir
+
+This is accidentally triggered by multiple versions of Docker.  Drop
+the test pending a Docker fix.
+
+Reverts part of 0319ef1d40ff39d2c0f942a46fb73918669b2350.
+
+https://github.com/moby/moby/issues/39475
+---
+ fs/overlayfs/super.c | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/fs/overlayfs/super.c b/fs/overlayfs/super.c
+index 2d028c02621f..64bca1f53884 100644
+--- a/fs/overlayfs/super.c
++++ b/fs/overlayfs/super.c
+@@ -1289,12 +1289,6 @@ static int ovl_get_lower_layers(struct super_block *sb, struct ovl_fs *ofs,
+ 		if (err < 0)
+ 			goto out;
+ 
+-		err = -EBUSY;
+-		if (ovl_is_inuse(stack[i].dentry)) {
+-			pr_err("overlayfs: lowerdir is in-use as upperdir/workdir\n");
+-			goto out;
+-		}
+-
+ 		err = ovl_setup_trap(sb, stack[i].dentry, &trap, "lowerdir");
+ 		if (err)
+ 			goto out;
+-- 
+2.21.0
+


### PR DESCRIPTION
https://github.com/coreos/linux/pull/339