### PR TITLE
[build-2191] profiles/oem-aci: provide old python

### DIFF
--- a/profiles/coreos/targets/generic/oem-aci/package.provided
+++ b/profiles/coreos/targets/generic/oem-aci/package.provided
@@ -2,4 +2,4 @@
 sys-auth/sssd-1.13.1
 
 # Stick to one version of Python in the ACI.
-dev-lang/python-3.6.5
+dev-lang/python-2.7


### PR DESCRIPTION
This ensures the gce agent ACI has python. For unknown reasons including
python-3.6.5 in package.provided causes both python 3.x and 2.x to be
removed but we still need 2.x.

I don't know why this works. Any version older than the 2.7 version we
use works. Portage appears to be doing the opposite of what it should
be.